### PR TITLE
[wa_dnr_forest_health_tracker/#1517] Make Focus Area required when cr…

### DIFF
--- a/Database/ReleaseScript/0324 - Placeholder -- next script.sql
+++ b/Database/ReleaseScript/0324 - Placeholder -- next script.sql
@@ -1,1 +1,0 @@
--- Feel free to use this script 

--- a/Database/ReleaseScript/0325 - Project and ProjectUpdate tables_ make FocusAreaID not null.sql
+++ b/Database/ReleaseScript/0325 - Project and ProjectUpdate tables_ make FocusAreaID not null.sql
@@ -1,0 +1,10 @@
+--No null FocusAreaID records in Project, so locking down FocusAreaID
+alter table dbo.Project
+alter column FocusAreaID int not null
+GO
+
+alter table dbo.ProjectUpdate
+alter column FocusAreaID int not null
+GO
+
+--

--- a/Database/Tables/dbo.Project.sql
+++ b/Database/Tables/dbo.Project.sql
@@ -26,7 +26,7 @@ CREATE TABLE [dbo].[Project](
 	[ReviewedByPersonID] [int] NULL,
 	[DefaultBoundingBox] [geometry] NULL,
 	[NoExpendituresToReportExplanation] [varchar](max) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
-	[FocusAreaID] [int] NULL,
+	[FocusAreaID] [int] NOT NULL,
 	[NoRegionsExplanation] [varchar](4000) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
 	[NoPriorityAreasExplanation] [varchar](4000) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
 	[ExpirationDate] [datetime] NULL,

--- a/Database/Tables/dbo.ProjectUpdate.sql
+++ b/Database/Tables/dbo.ProjectUpdate.sql
@@ -14,7 +14,7 @@ CREATE TABLE [dbo].[ProjectUpdate](
 	[PlannedDate] [datetime] NULL,
 	[ProjectLocationSimpleTypeID] [int] NOT NULL,
 	[PrimaryContactPersonID] [int] NULL,
-	[FocusAreaID] [int] NULL,
+	[FocusAreaID] [int] NOT NULL,
 	[ExpirationDate] [datetime] NULL,
  CONSTRAINT [PK_ProjectUpdate_ProjectUpdateID] PRIMARY KEY CLUSTERED 
 (

--- a/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectCreateController.cs
@@ -179,12 +179,14 @@ namespace ProjectFirma.Web.Controllers
         private ActionResult CreateAndEditBasicsPostImpl(BasicsViewModel viewModel)
         {
             var project = new Project(viewModel.ProjectTypeID ?? ModelObjectHelpers.NotYetAssignedID,
-                viewModel.ProjectStageID ?? ModelObjectHelpers.NotYetAssignedID,
-                viewModel.ProjectName,
-                viewModel.ProjectDescription,
-                false,
-                ProjectLocationSimpleType.None.ProjectLocationSimpleTypeID,
-                ProjectApprovalStatus.Draft.ProjectApprovalStatusID)
+                                      viewModel.ProjectStageID ?? ModelObjectHelpers.NotYetAssignedID,
+                                      viewModel.ProjectName,
+                                      viewModel.ProjectDescription,
+                                      false,
+                                      ProjectLocationSimpleType.None.ProjectLocationSimpleTypeID,
+                                      ProjectApprovalStatus.Draft.ProjectApprovalStatusID,
+                                      viewModel.FocusAreaID 
+                                    )
             {
                 ProposingPerson = CurrentPerson,
                 ProposingDate = DateTime.Now

--- a/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ProjectUpdateController.cs
@@ -2329,7 +2329,8 @@ namespace ProjectFirma.Web.Controllers
             var dummyProject = Project.CreateNewBlank(ProjectType.CreateNewBlank(TaxonomyBranch.CreateNewBlank(TaxonomyTrunk.CreateNewBlank())),
                 ProjectStage.Completed,
                 ProjectLocationSimpleType.None,
-                ProjectApprovalStatus.Approved);
+                ProjectApprovalStatus.Approved,
+                FocusArea.CreateNewBlank(FocusAreaStatus.Completed, Region.CreateNewBlank()));
 
             var dummyProjectUpdateBatch = ProjectUpdateBatch.CreateNewBlank(dummyProject, CurrentPerson, ProjectUpdateState.Created);
 

--- a/Source/ProjectFirma.Web/DatabaseEntities.csdl
+++ b/Source/ProjectFirma.Web/DatabaseEntities.csdl
@@ -1610,7 +1610,7 @@
     <Property Name="ReviewedByPersonID" Type="Int32" />
     <Property Name="DefaultBoundingBox" Type="Geometry" />
     <Property Name="NoExpendituresToReportExplanation" Type="String" MaxLength="Max" Unicode="false" FixedLength="false" />
-    <Property Name="FocusAreaID" Type="Int32" />
+    <Property Name="FocusAreaID" Type="Int32" Nullable="false" />
     <Property Name="NoRegionsExplanation" Type="String" MaxLength="4000" Unicode="false" FixedLength="false" />
     <Property Name="NoPriorityAreasExplanation" Type="String" MaxLength="4000" Unicode="false" FixedLength="false" />
     <Property Name="ExpirationDate" Type="DateTime" />
@@ -2108,7 +2108,7 @@
     <Property Name="PlannedDate" Type="DateTime" />
     <Property Name="ProjectLocationSimpleTypeID" Type="Int32" Nullable="false" />
     <Property Name="PrimaryContactPersonID" Type="Int32" />
-    <Property Name="FocusAreaID" Type="Int32" />
+    <Property Name="FocusAreaID" Type="Int32" Nullable="false" />
     <Property Name="ExpirationDate" Type="DateTime" />
     <NavigationProperty Name="FocusArea" Relationship="ProjectFirma.Web.Models.FK_ProjectUpdate_FocusArea_FocusAreaID" FromRole="ProjectUpdates" ToRole="FocusArea" />
     <NavigationProperty Name="PrimaryContactPerson" Relationship="ProjectFirma.Web.Models.FK_ProjectUpdate_Person_PrimaryContactPersonID_PersonID" FromRole="ProjectUpdatesWhereYouAreThePrimaryContactPerson" ToRole="PrimaryContactPerson" />
@@ -2827,7 +2827,7 @@
     </ReferentialConstraint>
   </Association>
   <Association Name="FK_Project_FocusArea_FocusAreaID">
-    <End Role="FocusArea" Type="ProjectFirma.Web.Models.FocusArea" Multiplicity="0..1" />
+    <End Role="FocusArea" Type="ProjectFirma.Web.Models.FocusArea" Multiplicity="1" />
     <End Role="Projects" Type="ProjectFirma.Web.Models.Project" Multiplicity="*" />
     <ReferentialConstraint>
       <Principal Role="FocusArea">
@@ -2839,7 +2839,7 @@
     </ReferentialConstraint>
   </Association>
   <Association Name="FK_ProjectUpdate_FocusArea_FocusAreaID">
-    <End Role="FocusArea" Type="ProjectFirma.Web.Models.FocusArea" Multiplicity="0..1" />
+    <End Role="FocusArea" Type="ProjectFirma.Web.Models.FocusArea" Multiplicity="1" />
     <End Role="ProjectUpdates" Type="ProjectFirma.Web.Models.ProjectUpdate" Multiplicity="*" />
     <ReferentialConstraint>
       <Principal Role="FocusArea">

--- a/Source/ProjectFirma.Web/DatabaseEntities.ssdl
+++ b/Source/ProjectFirma.Web/DatabaseEntities.ssdl
@@ -1420,7 +1420,7 @@ warning 6035: The relationship 'FK_PerformanceMeasureActualSubcategoryOption_Per
     <Property Name="ReviewedByPersonID" Type="int" />
     <Property Name="DefaultBoundingBox" Type="geometry" />
     <Property Name="NoExpendituresToReportExplanation" Type="varchar(max)" />
-    <Property Name="FocusAreaID" Type="int" />
+    <Property Name="FocusAreaID" Type="int" Nullable="false" />
     <Property Name="NoRegionsExplanation" Type="varchar" MaxLength="4000" />
     <Property Name="NoPriorityAreasExplanation" Type="varchar" MaxLength="4000" />
     <Property Name="ExpirationDate" Type="datetime" />
@@ -1811,7 +1811,7 @@ warning 6035: The relationship 'FK_PerformanceMeasureActualSubcategoryOption_Per
     <Property Name="PlannedDate" Type="datetime" />
     <Property Name="ProjectLocationSimpleTypeID" Type="int" Nullable="false" />
     <Property Name="PrimaryContactPersonID" Type="int" />
-    <Property Name="FocusAreaID" Type="int" />
+    <Property Name="FocusAreaID" Type="int" Nullable="false" />
     <Property Name="ExpirationDate" Type="datetime" />
   </EntityType>
   <EntityType Name="ProjectUpdateBatch">
@@ -3107,7 +3107,7 @@ warning 6002: The table/view 'WADNRForestHealthDB.dbo.vGeoServerRegion' does not
     </ReferentialConstraint>
   </Association>
   <Association Name="FK_Project_FocusArea_FocusAreaID">
-    <End Role="FocusArea" Type="ProjectFirma.Web.Models.Store.FocusArea" Multiplicity="0..1" />
+    <End Role="FocusArea" Type="ProjectFirma.Web.Models.Store.FocusArea" Multiplicity="1" />
     <End Role="Projects" Type="ProjectFirma.Web.Models.Store.Project" Multiplicity="*" />
     <ReferentialConstraint>
       <Principal Role="FocusArea">
@@ -3995,7 +3995,7 @@ warning 6002: The table/view 'WADNRForestHealthDB.dbo.vGeoServerRegion' does not
     </ReferentialConstraint>
   </Association>
   <Association Name="FK_ProjectUpdate_FocusArea_FocusAreaID">
-    <End Role="FocusArea" Type="ProjectFirma.Web.Models.Store.FocusArea" Multiplicity="0..1" />
+    <End Role="FocusArea" Type="ProjectFirma.Web.Models.Store.FocusArea" Multiplicity="1" />
     <End Role="ProjectUpdates" Type="ProjectFirma.Web.Models.Store.ProjectUpdate" Multiplicity="*" />
     <ReferentialConstraint>
       <Principal Role="FocusArea">

--- a/Source/ProjectFirma.Web/Models/Generated/Project.Binding.cs
+++ b/Source/ProjectFirma.Web/Models/Generated/Project.Binding.cs
@@ -51,7 +51,7 @@ namespace ProjectFirma.Web.Models
         /// <summary>
         /// Constructor for building a new object with MaximalConstructor required fields in preparation for insert into database
         /// </summary>
-        public Project(int projectID, int projectTypeID, int projectStageID, string projectName, string projectDescription, DateTime? completionDate, decimal? estimatedTotalCost, DbGeometry projectLocationPoint, string performanceMeasureActualYearsExemptionExplanation, bool isFeatured, string projectLocationNotes, DateTime? plannedDate, int projectLocationSimpleTypeID, int? primaryContactPersonID, int projectApprovalStatusID, int? proposingPersonID, DateTime? proposingDate, string performanceMeasureNotes, DateTime? submissionDate, DateTime? approvalDate, int? reviewedByPersonID, DbGeometry defaultBoundingBox, string noExpendituresToReportExplanation, int? focusAreaID, string noRegionsExplanation, string noPriorityAreasExplanation, DateTime? expirationDate) : this()
+        public Project(int projectID, int projectTypeID, int projectStageID, string projectName, string projectDescription, DateTime? completionDate, decimal? estimatedTotalCost, DbGeometry projectLocationPoint, string performanceMeasureActualYearsExemptionExplanation, bool isFeatured, string projectLocationNotes, DateTime? plannedDate, int projectLocationSimpleTypeID, int? primaryContactPersonID, int projectApprovalStatusID, int? proposingPersonID, DateTime? proposingDate, string performanceMeasureNotes, DateTime? submissionDate, DateTime? approvalDate, int? reviewedByPersonID, DbGeometry defaultBoundingBox, string noExpendituresToReportExplanation, int focusAreaID, string noRegionsExplanation, string noPriorityAreasExplanation, DateTime? expirationDate) : this()
         {
             this.ProjectID = projectID;
             this.ProjectTypeID = projectTypeID;
@@ -85,7 +85,7 @@ namespace ProjectFirma.Web.Models
         /// <summary>
         /// Constructor for building a new object with MinimalConstructor required fields in preparation for insert into database
         /// </summary>
-        public Project(int projectTypeID, int projectStageID, string projectName, string projectDescription, bool isFeatured, int projectLocationSimpleTypeID, int projectApprovalStatusID) : this()
+        public Project(int projectTypeID, int projectStageID, string projectName, string projectDescription, bool isFeatured, int projectLocationSimpleTypeID, int projectApprovalStatusID, int focusAreaID) : this()
         {
             // Mark this as a new object by setting primary key with special value
             this.ProjectID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
@@ -97,12 +97,13 @@ namespace ProjectFirma.Web.Models
             this.IsFeatured = isFeatured;
             this.ProjectLocationSimpleTypeID = projectLocationSimpleTypeID;
             this.ProjectApprovalStatusID = projectApprovalStatusID;
+            this.FocusAreaID = focusAreaID;
         }
 
         /// <summary>
         /// Constructor for building a new object with MinimalConstructor required fields, using objects whenever possible
         /// </summary>
-        public Project(ProjectType projectType, ProjectStage projectStage, string projectName, string projectDescription, bool isFeatured, ProjectLocationSimpleType projectLocationSimpleType, ProjectApprovalStatus projectApprovalStatus) : this()
+        public Project(ProjectType projectType, ProjectStage projectStage, string projectName, string projectDescription, bool isFeatured, ProjectLocationSimpleType projectLocationSimpleType, ProjectApprovalStatus projectApprovalStatus, FocusArea focusArea) : this()
         {
             // Mark this as a new object by setting primary key with special value
             this.ProjectID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
@@ -115,14 +116,17 @@ namespace ProjectFirma.Web.Models
             this.IsFeatured = isFeatured;
             this.ProjectLocationSimpleTypeID = projectLocationSimpleType.ProjectLocationSimpleTypeID;
             this.ProjectApprovalStatusID = projectApprovalStatus.ProjectApprovalStatusID;
+            this.FocusAreaID = focusArea.FocusAreaID;
+            this.FocusArea = focusArea;
+            focusArea.Projects.Add(this);
         }
 
         /// <summary>
         /// Creates a "blank" object of this type and populates primitives with defaults
         /// </summary>
-        public static Project CreateNewBlank(ProjectType projectType, ProjectStage projectStage, ProjectLocationSimpleType projectLocationSimpleType, ProjectApprovalStatus projectApprovalStatus)
+        public static Project CreateNewBlank(ProjectType projectType, ProjectStage projectStage, ProjectLocationSimpleType projectLocationSimpleType, ProjectApprovalStatus projectApprovalStatus, FocusArea focusArea)
         {
-            return new Project(projectType, projectStage, default(string), default(string), default(bool), projectLocationSimpleType, projectApprovalStatus);
+            return new Project(projectType, projectStage, default(string), default(string), default(bool), projectLocationSimpleType, projectApprovalStatus, focusArea);
         }
 
         /// <summary>
@@ -297,7 +301,7 @@ namespace ProjectFirma.Web.Models
         public int? ReviewedByPersonID { get; set; }
         public DbGeometry DefaultBoundingBox { get; set; }
         public string NoExpendituresToReportExplanation { get; set; }
-        public int? FocusAreaID { get; set; }
+        public int FocusAreaID { get; set; }
         public string NoRegionsExplanation { get; set; }
         public string NoPriorityAreasExplanation { get; set; }
         public DateTime? ExpirationDate { get; set; }

--- a/Source/ProjectFirma.Web/Models/Generated/ProjectUpdate.Binding.cs
+++ b/Source/ProjectFirma.Web/Models/Generated/ProjectUpdate.Binding.cs
@@ -30,7 +30,7 @@ namespace ProjectFirma.Web.Models
         /// <summary>
         /// Constructor for building a new object with MaximalConstructor required fields in preparation for insert into database
         /// </summary>
-        public ProjectUpdate(int projectUpdateID, int projectUpdateBatchID, int projectStageID, string projectDescription, DateTime? completionDate, decimal? estimatedTotalCost, DbGeometry projectLocationPoint, string projectLocationNotes, DateTime? plannedDate, int projectLocationSimpleTypeID, int? primaryContactPersonID, int? focusAreaID, DateTime? expirationDate) : this()
+        public ProjectUpdate(int projectUpdateID, int projectUpdateBatchID, int projectStageID, string projectDescription, DateTime? completionDate, decimal? estimatedTotalCost, DbGeometry projectLocationPoint, string projectLocationNotes, DateTime? plannedDate, int projectLocationSimpleTypeID, int? primaryContactPersonID, int focusAreaID, DateTime? expirationDate) : this()
         {
             this.ProjectUpdateID = projectUpdateID;
             this.ProjectUpdateBatchID = projectUpdateBatchID;
@@ -50,7 +50,7 @@ namespace ProjectFirma.Web.Models
         /// <summary>
         /// Constructor for building a new object with MinimalConstructor required fields in preparation for insert into database
         /// </summary>
-        public ProjectUpdate(int projectUpdateBatchID, int projectStageID, string projectDescription, int projectLocationSimpleTypeID) : this()
+        public ProjectUpdate(int projectUpdateBatchID, int projectStageID, string projectDescription, int projectLocationSimpleTypeID, int focusAreaID) : this()
         {
             // Mark this as a new object by setting primary key with special value
             this.ProjectUpdateID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
@@ -59,12 +59,13 @@ namespace ProjectFirma.Web.Models
             this.ProjectStageID = projectStageID;
             this.ProjectDescription = projectDescription;
             this.ProjectLocationSimpleTypeID = projectLocationSimpleTypeID;
+            this.FocusAreaID = focusAreaID;
         }
 
         /// <summary>
         /// Constructor for building a new object with MinimalConstructor required fields, using objects whenever possible
         /// </summary>
-        public ProjectUpdate(ProjectUpdateBatch projectUpdateBatch, ProjectStage projectStage, string projectDescription, ProjectLocationSimpleType projectLocationSimpleType) : this()
+        public ProjectUpdate(ProjectUpdateBatch projectUpdateBatch, ProjectStage projectStage, string projectDescription, ProjectLocationSimpleType projectLocationSimpleType, FocusArea focusArea) : this()
         {
             // Mark this as a new object by setting primary key with special value
             this.ProjectUpdateID = ModelObjectHelpers.MakeNextUnsavedPrimaryKeyValue();
@@ -73,14 +74,17 @@ namespace ProjectFirma.Web.Models
             this.ProjectStageID = projectStage.ProjectStageID;
             this.ProjectDescription = projectDescription;
             this.ProjectLocationSimpleTypeID = projectLocationSimpleType.ProjectLocationSimpleTypeID;
+            this.FocusAreaID = focusArea.FocusAreaID;
+            this.FocusArea = focusArea;
+            focusArea.ProjectUpdates.Add(this);
         }
 
         /// <summary>
         /// Creates a "blank" object of this type and populates primitives with defaults
         /// </summary>
-        public static ProjectUpdate CreateNewBlank(ProjectUpdateBatch projectUpdateBatch, ProjectStage projectStage, ProjectLocationSimpleType projectLocationSimpleType)
+        public static ProjectUpdate CreateNewBlank(ProjectUpdateBatch projectUpdateBatch, ProjectStage projectStage, ProjectLocationSimpleType projectLocationSimpleType, FocusArea focusArea)
         {
-            return new ProjectUpdate(projectUpdateBatch, projectStage, default(string), projectLocationSimpleType);
+            return new ProjectUpdate(projectUpdateBatch, projectStage, default(string), projectLocationSimpleType, focusArea);
         }
 
         /// <summary>
@@ -127,7 +131,7 @@ namespace ProjectFirma.Web.Models
         public DateTime? PlannedDate { get; set; }
         public int ProjectLocationSimpleTypeID { get; set; }
         public int? PrimaryContactPersonID { get; set; }
-        public int? FocusAreaID { get; set; }
+        public int FocusAreaID { get; set; }
         public DateTime? ExpirationDate { get; set; }
         [NotMapped]
         public int PrimaryKey { get { return ProjectUpdateID; } set { ProjectUpdateID = value; } }

--- a/Source/ProjectFirma.Web/Models/ProjectLocationFilterTypeTest.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectLocationFilterTypeTest.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Data.Entity.Spatial;
 using System.Linq;
 using NUnit.Framework;
+using ProjectFirma.Web.UnitTestCommon;
 
 namespace ProjectFirma.Web.Models
 {
@@ -32,12 +33,14 @@ namespace ProjectFirma.Web.Models
         [Ignore]
         public void TestProjectLocationFilterTypesAddedAsProjectProperties()
         {
+            var focusArea = TestFramework.TestFocusArea.Create();
+
             var project = Project.CreateNewBlank(
                 ProjectType.CreateNewBlank(TaxonomyBranch.CreateNewBlank(TaxonomyTrunk.CreateNewBlank())),
                 ProjectStage.Completed,
                 ProjectLocationSimpleType.None,
                 // TODO: Verify that "Approved" is the correct project state or use the correct value
-                ProjectApprovalStatus.Approved);
+                ProjectApprovalStatus.Approved, focusArea);
 
             project.ProjectLocationPoint = DbGeometry.PointFromText("POINT(29.11 40.11)", 4326);
 

--- a/Source/ProjectFirma.Web/Models/ProjectUpdate.cs
+++ b/Source/ProjectFirma.Web/Models/ProjectUpdate.cs
@@ -43,7 +43,8 @@ namespace ProjectFirma.Web.Models
                 : 0;
         }
 
-        public ProjectUpdate(ProjectUpdateBatch projectUpdateBatch) : this(projectUpdateBatch, projectUpdateBatch.Project.ProjectStage, projectUpdateBatch.Project.ProjectDescription, projectUpdateBatch.Project.ProjectLocationSimpleType)
+        public ProjectUpdate(ProjectUpdateBatch projectUpdateBatch) : this(projectUpdateBatch, projectUpdateBatch.Project.ProjectStage, projectUpdateBatch.Project.ProjectDescription, 
+                                                                           projectUpdateBatch.Project.ProjectLocationSimpleType, projectUpdateBatch.Project.FocusArea)
         {
             var project = projectUpdateBatch.Project;
             LoadUpdateFromProject(project);

--- a/Source/ProjectFirma.Web/Models/TreatmentActivityModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/TreatmentActivityModelExtensions.cs
@@ -68,12 +68,7 @@ namespace ProjectFirma.Web.Models
         }
         public static string GetProjectFocusAreaUrl(this Models.TreatmentActivity treatmentActivity)
         {
-            var result = string.Empty;
-            if (treatmentActivity.Project.FocusAreaID != null)
-            {
-                result = SitkaRoute<FocusAreaController>.BuildUrlFromExpression(fac => fac.Detail(treatmentActivity.Project.FocusAreaID));
-            }
-
+            string result = SitkaRoute<FocusAreaController>.BuildUrlFromExpression(fac => fac.Detail(treatmentActivity.Project.FocusAreaID));        
             return result;
         }
         
@@ -95,17 +90,7 @@ namespace ProjectFirma.Web.Models
 
         public static HtmlString GetFocusAreaText(this Models.TreatmentActivity treatmentActivity)
         {
-            HtmlString returnValue = new HtmlString(string.Empty);
-            if (treatmentActivity.Project.FocusAreaID == null)
-            {
-                returnValue = "".ToHTMLFormattedString();
-            }
-            else
-            {
-                returnValue = UrlTemplate.MakeHrefString(treatmentActivity.GetProjectFocusAreaUrl(),
-                    treatmentActivity.GetProjectFocusAreaName());
-            }
-
+            HtmlString returnValue = UrlTemplate.MakeHrefString(treatmentActivity.GetProjectFocusAreaUrl(), treatmentActivity.GetProjectFocusAreaName());
             return returnValue;
         }
 

--- a/Source/ProjectFirma.Web/UnitTestCommon/TestProject.cs
+++ b/Source/ProjectFirma.Web/UnitTestCommon/TestProject.cs
@@ -33,24 +33,25 @@ namespace ProjectFirma.Web.UnitTestCommon
                 var projectType = TestProjectType.Create();
                 var projectStage = ProjectStage.Planned;
                 // TODO: Verify that "Approved" is the correct project state or use the correct value
-                var project = Project.CreateNewBlank(projectType, projectStage, ProjectLocationSimpleType.None,
-                     ProjectApprovalStatus.Approved);
+                var project = Project.CreateNewBlank(projectType, projectStage, ProjectLocationSimpleType.None, ProjectApprovalStatus.Approved, FocusArea.CreateNewBlank(FocusAreaStatus.InProgress, Region.CreateNewBlank()));
                 return project;
             }
 
             public static Project Create(DatabaseEntities dbContext)
             {
                 var projectType = TestProjectType.Create(dbContext);
-
                 var projectStage = ProjectStage.Planned;
+                var focusArea = TestFocusArea.Create();
+
                 var project = new Project(projectType,
                     projectStage,
-                    string.Format("Test Project Name {0}", Guid.NewGuid()),
+                    $"Test Project Name {Guid.NewGuid()}",
                     MakeTestName("Test Project Description"),
                     false,
                     ProjectLocationSimpleType.None,
                     // TODO: Verify that this is correct or use the correct value
-                    ProjectApprovalStatus.Approved);
+                    ProjectApprovalStatus.Approved,
+                    focusArea);
 
                 dbContext.Projects.Add(project);
                 return project;
@@ -60,8 +61,10 @@ namespace ProjectFirma.Web.UnitTestCommon
             {
                 var projectType = TestProjectType.Create();
                 var projectStage = ProjectStage.Implementation;
+                var focusArea = TestFocusArea.Create();
+
                 // TODO: Verify that "Approved" is the correct project state or use the correct value
-                var project = new Project(projectType, projectStage, projectName, "Some description",  false, ProjectLocationSimpleType.None, ProjectApprovalStatus.Approved)
+                var project = new Project(projectType, projectStage, projectName, "Some description",  false, ProjectLocationSimpleType.None, ProjectApprovalStatus.Approved, focusArea)
                 {
                     ProjectID = projectID
                 };

--- a/Source/ProjectFirma.Web/UnitTestCommon/TestProjectType.cs
+++ b/Source/ProjectFirma.Web/UnitTestCommon/TestProjectType.cs
@@ -45,5 +45,15 @@ namespace ProjectFirma.Web.UnitTestCommon
                 return newProjectType;
             }
         }
+
+        public static class TestFocusArea
+        {
+            public static FocusArea Create()
+            {
+                var focusArea = FocusArea.CreateNewBlank(FocusAreaStatus.InProgress, Region.CreateNewBlank());
+                return focusArea;
+            }
+        }
+
     }
 }

--- a/Source/ProjectFirma.Web/UnitTestCommon/TestProjectUpdate.cs
+++ b/Source/ProjectFirma.Web/UnitTestCommon/TestProjectUpdate.cs
@@ -34,7 +34,8 @@ namespace ProjectFirma.Web.UnitTestCommon
 
             public static ProjectUpdate Create(ProjectUpdateBatch projectUpdateBatch)
             {
-                var projectUpdate = new ProjectUpdate(projectUpdateBatch, ProjectStage.Planned, MakeTestName("Project Description"), ProjectLocationSimpleType.None);
+                var focusArea = TestFocusArea.Create();
+                var projectUpdate = new ProjectUpdate(projectUpdateBatch, ProjectStage.Planned, MakeTestName("Project Description"), ProjectLocationSimpleType.None, focusArea);
                 projectUpdateBatch.ProjectUpdate = projectUpdate;
                 return projectUpdate;
             }

--- a/Source/ProjectFirma.Web/Views/ProjectCreate/BasicsViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectCreate/BasicsViewModel.cs
@@ -63,7 +63,8 @@ namespace ProjectFirma.Web.Views.ProjectCreate
         public DateTime? CompletionDate { get; set; }
 
 		[FieldDefinitionDisplay(FieldDefinitionEnum.FocusArea)]
-        public int? FocusAreaID { get; set; }
+        [Required]
+        public int FocusAreaID { get; set; }
 
         public int? ImportExternalProjectStagingID { get; set; }
 
@@ -101,7 +102,6 @@ namespace ProjectFirma.Web.Views.ProjectCreate
             project.ExpirationDate = ExpirationDate;
             project.CompletionDate = CompletionDate;
             project.FocusAreaID = FocusAreaID;
-
 
             var nonAllTypeAttributes = project.ProjectCustomAttributes.Where(x => !x.ProjectCustomAttributeType.ApplyToAllProjectTypes).ToList();
             if (nonAllTypeAttributes.Any())
@@ -196,11 +196,11 @@ namespace ProjectFirma.Web.Views.ProjectCreate
 
             var projectTypeIDsWhereFocusAreaRequired = Models.ProjectType.GetAllProjectTypeIDsWhereFocusAreaRequired();
 
-            if (FocusAreaID == null && projectTypeIDsWhereFocusAreaRequired.Contains(ProjectTypeID.Value))
-            {
-                var errorMessage = $"Focus Area is required for your selected {Models.FieldDefinition.ProjectType.GetFieldDefinitionLabel()}";
-                yield return new SitkaValidationResult<BasicsViewModel, int?>(errorMessage, m => m.FocusAreaID);
-            }
+            //if (FocusAreaID == null && projectTypeIDsWhereFocusAreaRequired.Contains(ProjectTypeID.Value))
+            //{
+            //    var errorMessage = $"Focus Area is required for your selected {Models.FieldDefinition.ProjectType.GetFieldDefinitionLabel()}";
+            //    yield return new SitkaValidationResult<BasicsViewModel, int?>(errorMessage, m => m.FocusAreaID);
+            //}
         }
     }
 }

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/Basics.cshtml
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/Basics.cshtml
@@ -135,7 +135,7 @@
 
         <div class="form-group">
             <div class="col-xs-12 col-sm-4 control-label">
-                @Html.LabelWithSugarFor(m => m.FocusAreaID)
+                @Html.LabelWithSugarFor(m => m.FocusAreaID, true)
             </div>
             <div class="col-xs-12 col-sm-8">
                 @Html.DropDownListFor(m => m.FocusAreaID, ViewDataTyped.FocusAreas, new { @class = "form-control", style = "width: auto;" })

--- a/Source/ProjectFirma.Web/Views/ProjectUpdate/BasicsViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/ProjectUpdate/BasicsViewModel.cs
@@ -27,6 +27,7 @@ using ProjectFirma.Web.Common;
 using ProjectFirma.Web.Models;
 using FluentValidation.Attributes;
 using LtInfo.Common;
+using LtInfo.Common.DesignByContract;
 using LtInfo.Common.Models;
 
 namespace ProjectFirma.Web.Views.ProjectUpdate
@@ -54,7 +55,7 @@ namespace ProjectFirma.Web.Views.ProjectUpdate
         public DateTime? CompletionDate { get; set; }
 
         [FieldDefinitionDisplay(FieldDefinitionEnum.FocusArea)]
-        public int? FocusAreaID { get; set; }
+        public int FocusAreaID { get; set; }
         [DisplayName("Reviewer Comments")]
         [StringLength(ProjectUpdateBatch.FieldLengths.BasicsComment)]
         public string Comments { get; set; }

--- a/Source/ProjectFirma.Web/Views/Shared/ProjectControls/EditProjectViewModel.cs
+++ b/Source/ProjectFirma.Web/Views/Shared/ProjectControls/EditProjectViewModel.cs
@@ -67,7 +67,7 @@ namespace ProjectFirma.Web.Views.Shared.ProjectControls
 
         public int? OldProjectStageID { get; set; }
 
-        public int? FocusAreaID { get; set; }
+        public int FocusAreaID { get; set; }
 
 
         /// <summary>
@@ -168,11 +168,11 @@ namespace ProjectFirma.Web.Views.Shared.ProjectControls
 
             var projectTypeIDsWhereFocusAreaRequired = Models.ProjectType.GetAllProjectTypeIDsWhereFocusAreaRequired();
 
-            if (FocusAreaID == null && projectTypeIDsWhereFocusAreaRequired.Contains(ProjectTypeID.Value))
-            {
-                var errorMessage = $"Focus Area is required for your selected {Models.FieldDefinition.ProjectType.GetFieldDefinitionLabel()}";
-                yield return new SitkaValidationResult<EditProjectViewModel, int?>(errorMessage, m => m.FocusAreaID);
-            }
+            //if (FocusAreaID == null && projectTypeIDsWhereFocusAreaRequired.Contains(ProjectTypeID.Value))
+            //{
+            //    var errorMessage = $"Focus Area is required for your selected {Models.FieldDefinition.ProjectType.GetFieldDefinitionLabel()}";
+            //    yield return new SitkaValidationResult<EditProjectViewModel, int?>(errorMessage, m => m.FocusAreaID);
+            //}
         }
     }
 }

--- a/Source/ProjectFirma.Web/Web.config_temp
+++ b/Source/ProjectFirma.Web/Web.config_temp
@@ -1,0 +1,493 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+  </configSections>
+  <appSettings>
+    <add key="FirmaEnvironment" value="local" />
+    <add key="vs:EnableBrowserLink" value="false" />
+    <add key="webpages:Version" value="3.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="PreserveLoginUrl" value="true" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+    <add key="CacheStaticContentTimeSpan" value="00:00:00" />
+    <add key="UseMvcExtensionInUrl" value="false" />
+    <add key="SitkaEmailRedirect" value="test@localhost.sitkatech.com" />
+    <add key="IsEmailEnabled" value="true" />
+    <add key="MailLogBcc" value="" />
+    <add key="MaximumAllowedUploadFileSize" value="100000000" />
+    <add key="MaximumAllowedUploadImageSize" value="4000000" />
+    <add key="DatabaseConnectionString" value="Server=localhost;Database=WADNRForestHealthDB;Trusted_Connection=True" />
+    <add key="RecaptchaValidatorUrl" value="https://www.google.com/recaptcha/api/siteverify" />
+    <add key="SitkaSupportEmail" value="projectfirma@sitkatech.com" />
+    <add key="DoNotReplyEmail" value="donotreply@projectfirma.com" />
+    <add key="CanonicalHostName" value="wadnrforesthealth.localhost.projectfirma.com" />
+    <add key="ApplicationDomain" value="projectfirma.com" />
+    <add key="Ogr2OgrExecutable" value="C:\Program Files\GDAL\ogr2ogr.exe" />
+    <add key="OgrInfoExecutable" value="C:\Program Files\GDAL\ogrinfo.exe" />
+    <add key="DefaultSupportPersonID" value="2" />
+    <add key="LogFileFolder" value="C:\Sitka\WADNRForestHealth\Logs" />
+    <add key="SAWUrl" value="https://test-secureaccess.wa.gov" />
+    <add key="Saml2EntityID" value="https://wadnrforesthealth.localhost.projectfirma.com" />
+    <add key="SAWEndPoint" value="https://test-secureaccess.wa.gov/FIM2/sps/sawidp/saml20/logininitial?PartnerId=https://wadnrforesthealth.localhost.projectfirma.com" />
+    <add key="SamlIDPCertificateThumbPrint" value="ab48cb677181078a70f3c25b739a05df16627145" />
+    <add key="ADFSEndPoint" value="https://ead.sts.wa.gov/adfs/ls/IdpInitiatedSignOn.aspx?LoginToRP=https://wadnrforesthealth.localhost.projectfirma.com" />
+    <add key="DefaultModalDialogButtonCssClasses" value="btn-firma,btn-xs" />
+    <add key="WkhtmltopdfExecutable" value="C:\Program Files\wkhtmltopdf\bin\wkhtmltopdf.exe" />
+    <add key="WebMapServiceUrl" value="https://localhost-wadnrforesthealth-mapserver.projectfirma.com/geoserver/WADNRForestHealth/wms" />
+  </appSettings>
+  <system.net>
+    <mailSettings>
+      <smtp>
+        <network host="localhost" />
+      </smtp>
+    </mailSettings>
+  </system.net>
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
+
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.6.2" />
+      </system.Web>
+  -->
+  <system.web>
+    <!-- this next line seems to be needed since moving to ASP.Net 4.0 - otherwise validation errors occur even despite the presence of ValidateInput(false) attribute on the controller action and the ValidatePageRequest=false in the page directive -->
+    <httpRuntime requestValidationMode="2.0" maxRequestLength="200000000" maxUrlLength="2048" maxQueryStringLength="2048" />
+    <compilation debug="true" targetFramework="4.6.2">
+      <assemblies>
+        <add assembly="System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
+      </assemblies>
+    </compilation>
+    <!-- ASP.NET session cookie should be httponly and secure -->
+    <httpCookies httpOnlyCookies="true" requireSSL="true" lockItem="true" />
+    <sessionState mode="Custom" customProvider="InMemorySessionStateStore" timeout="720">
+      <providers>
+        <add name="InMemorySessionStateStore" type="LtInfo.Common.Mvc.InMemorySessionStateStore" />
+      </providers>
+    </sessionState>
+    <authentication mode="None" />
+    <pages>
+      <namespaces />
+    </pages>
+    <trace enabled="true" pageOutput="false" mostRecent="true" requestLimit="100" localOnly="true" />
+  </system.web>
+  <system.webServer>
+    <validation validateIntegratedModeConfiguration="true" />
+    <!-- runAllManagedModulesForAllRequests forces all requests, even static content handlers to go through ASP.NET MVC which allows us to set caching headers and handle 404 errors -->
+    <modules runAllManagedModulesForAllRequests="true">
+        <remove name="FormsAuthentication" />
+    </modules>
+    <httpErrors existingResponse="PassThrough" />
+    <staticContent>
+      <!-- As of 07/20/2015 these are the correct mime types for font files. In the future these may be included with IIS 8 or above or may need to be tweaked to match W3C recommendations. -MF, RL -->
+      <remove fileExtension=".eot" />
+      <mimeMap fileExtension=".eot" mimeType="application/vnd.ms-fontobject" />
+      <remove fileExtension=".ttf" />
+      <mimeMap fileExtension=".ttf" mimeType="application/octet-stream" />
+      <remove fileExtension=".svg" />
+      <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
+      <remove fileExtension=".woff" />
+      <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
+      <remove fileExtension=".woff2" />
+      <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
+    </staticContent>
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-UA-Compatible" value="IE=edge" />
+        <!-- force Internet Explorer (IE) Compatibility View settings off, to use latest version regardless of browser settings. Compatibility doesn't work with dhtmlGrid -->
+      </customHeaders>
+    </httpProtocol>
+  </system.webServer>
+  <log4net>
+    <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
+      <param name="File" value="C:\Sitka\WADNRForestHealth\Logs\WEB.log" />
+      <param name="AppendToFile" value="true" />
+      <rollingStyle value="Date" />
+      <datePattern value="yyyyMMdd" />
+      <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date;%thread;%-5level;%logger;%message%newline" />
+      </layout>
+    </appender>
+    <appender name="TraceAppender" type="log4net.Appender.TraceAppender">
+      <immediateFlush value="true" />
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date;%thread;%-5level;%logger;%message%newline" />
+      </layout>
+    </appender>
+    <appender name="SmtpAppender" type="LtInfo.Common.SmtpAppenderWithPathAndExceptionTypeInSubject, LtInfo.Common">
+      <to value="appalerts-wadnrforesthealthtracker@sitkatech.com" />
+      <from value="Application Alerts WA DNR Forest Health Tracker &lt;appalerts-wadnrforesthealthtracker@sitkatech.com&gt;" />
+      <subject value="WADNRForestHealth Alert: local application error" />
+      <smtpHost value="localhost" />
+      <bufferSize value="1" />
+      <threshold value="ERROR" />
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date;%thread;%-5level;%logger;%newline%newline%message" />
+      </layout>
+    </appender>
+    <root>
+      <level value="debug" />
+      <appender-ref ref="TraceAppender" />
+      <appender-ref ref="FileAppender" />
+    </root>
+  </log4net>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Xml.XmlSerializer" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Xml.XDocument" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Xml.ReaderWriter" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Timer" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Tasks.Parallel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Tasks" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Overlapped" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Text.RegularExpressions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Text.Encoding.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Text.Encoding" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Security.SecureString" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Security.Principal" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Security.Cryptography.Algorithms" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Serialization.Xml" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.3.0" newVersion="4.1.3.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Serialization.Json" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Numerics" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Resources.ResourceManager" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Reflection.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Reflection.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Reflection" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.ObjectModel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Sockets" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Requests" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.NetworkInformation" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Http" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Linq.Queryable" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Linq.Parallel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Linq.Expressions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Linq" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.IO" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.IO.Compression" publicKeyToken="B77A5C561934E089" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Globalization.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Globalization" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Dynamic.Runtime" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.Tools" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.StackTrace" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.Debug" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.Contracts" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Data.Common" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.ComponentModel.EventBasedAsync" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.ComponentModel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Collections" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Collections.Concurrent" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
+			</dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebMatrix.Data" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-5.6.0.0" newVersion="5.6.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-5.6.0.0" newVersion="5.6.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-5.6.0.0" newVersion="5.6.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="MvcExtensions" publicKeyToken="ee6190c4449c24bc" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.5.1.0" newVersion="2.5.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="EntityFramework" publicKeyToken="b77a5c561934e089" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DocumentFormat.OpenXml" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.5.5631.0" newVersion="2.5.5631.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
+    </providers>
+  </entityFramework>
+  <connectionStrings>
+    <add name="DatabaseEntities" connectionString="metadata=res://ProjectFirma.Web/ProjectFirma.Web.DatabaseEntities.csdl|res://ProjectFirma.Web/ProjectFirma.Web.DatabaseEntities.ssdl|res://ProjectFirma.Web/ProjectFirma.Web.DatabaseEntities.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=localhost;initial catalog=WADNRForestHealthDB;Trusted_Connection=True;MultipleActiveResultSets=True;application name=EntityFramework&quot;" providerName="System.Data.EntityClient"/>
+    <add name="ProjectFirmaDbContext" connectionString="data source=localhost;initial catalog=WADNRForestHealthDB;Trusted_Connection=True;multipleactiveresultsets=True;application name=EntityFramework" providerName="System.Data.SqlClient" />
+  </connectionStrings>
+  <system.serviceModel>
+    <!-- Services being PUBLISHED -->
+    <!-- ======================== -->
+    <serviceHostingEnvironment multipleSiteBindingsEnabled="true" aspNetCompatibilityEnabled="true" minFreeMemoryPercentageToActivateService="0" />
+    <services>
+      <service name="ProjectFirma.Web.Service.WebServices" behaviorConfiguration="WebServices.ServiceBehavior">
+        <endpoint address="basicEndpoint" binding="basicHttpBinding" contract="ProjectFirma.Web.Service.IWebServices" bindingConfiguration="BasicHttpBinding_IWebServices" />
+        <endpoint address="mex" binding="mexHttpBinding" contract="IMetadataExchange" />
+      </service>
+    </services>
+    <behaviors>
+      <!-- Services being PUBLISHED -->
+      <serviceBehaviors>
+        <behavior name="WebServices.ServiceBehavior">
+          <!-- maxItemsInObjectGraph allows more objects to come back -->
+          <dataContractSerializer maxItemsInObjectGraph="2147483647" />
+          <!-- publish metadata for the service -->
+          <serviceMetadata httpGetEnabled="true" httpsGetEnabled="true" />
+          <!-- To receive exception details in faults for debugging purposes, set the value below to true. Set to false to avoid disclosing exception information -->
+          <serviceDebug includeExceptionDetailInFaults="true" />
+        </behavior>
+      </serviceBehaviors>
+      <!-- Services being CONSUMED -->
+      <endpointBehaviors>
+        <behavior name="WebServices.EndpointBehavior">
+          <dataContractSerializer maxItemsInObjectGraph="2147483647" />
+        </behavior>
+      </endpointBehaviors>
+    </behaviors>
+    <bindings>
+      <basicHttpBinding>
+        <binding name="HttpBindingWithVeryLargeLimits" closeTimeout="00:10:00" openTimeout="00:10:00" receiveTimeout="00:15:00" sendTimeout="00:15:00" allowCookies="false" bypassProxyOnLocal="false" hostNameComparisonMode="StrongWildcard" maxBufferPoolSize="2147483647" maxBufferSize="2147483647" maxReceivedMessageSize="2147483647" messageEncoding="Text" textEncoding="utf-8" transferMode="Buffered" useDefaultWebProxy="true">
+          <readerQuotas maxArrayLength="2147483647" maxNameTableCharCount="2147483647" maxStringContentLength="2147483647" maxDepth="2147483647" maxBytesPerRead="2147483647" />
+          <security mode="None">
+            <transport clientCredentialType="None" proxyCredentialType="None" realm="" />
+            <message clientCredentialType="UserName" algorithmSuite="Default" />
+          </security>
+        </binding>
+        <binding name="HttpsBindingWithVeryLargeLimits" closeTimeout="00:10:00" openTimeout="00:10:00" receiveTimeout="00:15:00" sendTimeout="00:15:00" allowCookies="false" bypassProxyOnLocal="false" hostNameComparisonMode="StrongWildcard" maxBufferPoolSize="2147483647" maxBufferSize="2147483647" maxReceivedMessageSize="2147483647" messageEncoding="Text" textEncoding="utf-8" transferMode="Buffered" useDefaultWebProxy="true">
+          <readerQuotas maxArrayLength="2147483647" maxNameTableCharCount="2147483647" maxStringContentLength="2147483647" maxDepth="2147483647" maxBytesPerRead="2147483647" />
+          <security mode="Transport">
+            <transport clientCredentialType="None" proxyCredentialType="None" realm="" />
+            <message clientCredentialType="UserName" algorithmSuite="Default" />
+          </security>
+        </binding>
+        <!-- Reference to self for use in unit testing for WebServices -->
+        <binding name="BasicHttpBinding_IWebServices" closeTimeout="00:01:00" openTimeout="00:01:00" receiveTimeout="00:10:00" sendTimeout="00:01:00" allowCookies="false" bypassProxyOnLocal="false" hostNameComparisonMode="StrongWildcard" maxBufferSize="2147483647" maxBufferPoolSize="2147483647" maxReceivedMessageSize="2147483647" messageEncoding="Text" textEncoding="utf-8" transferMode="Buffered" useDefaultWebProxy="true">
+          <readerQuotas maxDepth="32" maxStringContentLength="2147483647" maxArrayLength="2147483647" maxBytesPerRead="2147483647" maxNameTableCharCount="2147483647" />
+          <security mode="Transport">
+            <transport clientCredentialType="None" proxyCredentialType="None" realm="" />
+            <message clientCredentialType="UserName" algorithmSuite="Default" />
+          </security>
+        </binding>
+      </basicHttpBinding>
+    </bindings>
+  </system.serviceModel>
+</configuration>


### PR DESCRIPTION
…eating or updating a project - Made FocusAreaID not null in database Project and ProjectUpdate tables. Made FocusAreaID required on both, following existing pattern of passing required parameter to LabelWithSugarFor in ProjectUpdate, and adding a [Required] attribute to the BasicsViewModel in ProjectCreate workflow. Not sure why these patterns are different, but I followed them for now.