### PR TITLE
WADNR-1758 Duplicate Grant Allocations

### DIFF
--- a/Source/LtInfo.Common/DhtmlWrappers/DhtmlxGridHtmlHelpers.cs
+++ b/Source/LtInfo.Common/DhtmlWrappers/DhtmlxGridHtmlHelpers.cs
@@ -39,6 +39,7 @@ namespace LtInfo.Common.DhtmlWrappers
         public static readonly HtmlString PlusIconBootstrap = BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-plus-sign gi-1x blue");
         public static readonly HtmlString UndoIconBootstrap = BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-regular undo gi-1x blue");
         public static readonly HtmlString EditIconBootstrap = BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-edit gi-1x blue");
+        public static readonly HtmlString DuplicateIconBootstrap = BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-duplicate gi-1x blue");
         public static readonly HtmlString FileIconBootstrap = BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-file gi-1x blue");
         public static readonly HtmlString DeleteIconBootstrap = BootstrapHtmlHelpers.MakeGlyphIcon("glyphicon-trash gi-1x blue");
         public static readonly HtmlString OkCircleIconBootstrap = BootstrapHtmlHelpers.MakeGlyphIconWithHiddenText("glyphicon-ok-circle gi-1x blue", "Yes");
@@ -627,6 +628,14 @@ namespace LtInfo.Common.DhtmlWrappers
                 modalDialogForm.OnJavascriptReadyFunction,
                 null,
                 null);
+        }
+
+        /// <summary>
+        /// For making a duplicate icon on the grid with an editor in a jquery ui dialog
+        /// </summary>
+        public static HtmlString MakeDuplicateIconAndLinkBootstrap(string dialogContentUrl, int dialogWidth, string dialogTitle)
+        {
+            return MakeModalDialogLink($"{DuplicateIconBootstrap}<span style=\"display:none\">Duplicate</span>", dialogContentUrl, dialogWidth, dialogTitle, null);
         }
 
         /// <summary>

--- a/Source/ProjectFirma.Web/Controllers/GrantAllocationController.cs
+++ b/Source/ProjectFirma.Web/Controllers/GrantAllocationController.cs
@@ -177,6 +177,50 @@ namespace ProjectFirma.Web.Controllers
         }
 
         [HttpGet]
+        [GrantAllocationCreateFeature]
+        public PartialViewResult Duplicate(GrantAllocationPrimaryKey grantAllocationPrimaryKey)
+        {
+            var originalGrantAllocation = grantAllocationPrimaryKey.EntityObject;
+            Check.EnsureNotNull(originalGrantAllocation);
+            var relevantGrant = originalGrantAllocation.GrantModification.Grant;
+            
+            // Copy original grant allocation to new view model, except grant mod and allocation amount
+            var viewModel = new EditGrantAllocationViewModel(originalGrantAllocation);
+            viewModel.GrantModificationID = 0;
+            viewModel.AllocationAmount = null;
+            viewModel.GrantAllocationName = $"{viewModel.GrantAllocationName} - Copy";
+
+            // 6/29/20 TK (SLG EDIT) - Null is correct here. the Grant Allocation passed in is used to get any "Program Managers" assigned on
+            // a Grant Allocation that may have lost their "program manager" permissions
+            return GrantAllocationViewEdit(viewModel, EditGrantAllocationType.NewGrantAllocation, null, relevantGrant);
+        }
+
+        [HttpPost]
+        [GrantAllocationCreateFeature]
+        [AutomaticallyCallEntityFrameworkSaveChangesWhenModelValid]
+        public ActionResult Duplicate(GrantAllocationPrimaryKey grantAllocationPrimaryKey, EditGrantAllocationViewModel viewModel)
+        {
+            var originalGrantAllocation = grantAllocationPrimaryKey.EntityObject;
+            Check.EnsureNotNull(originalGrantAllocation);
+            var relevantGrant = originalGrantAllocation.GrantModification.Grant;
+            if (!ModelState.IsValid)
+            {
+                // 6/29/20 TK (SLG EDIT) - Null is correct here. the Grant Allocation passed in is used to get any "Program Managers" assigned on
+                // a Grant Allocation that may have lost their "program manager" permissions
+                return GrantAllocationViewEdit(viewModel, EditGrantAllocationType.NewGrantAllocation, null, relevantGrant);
+            }
+
+            var grantModification = HttpRequestStorage.DatabaseEntities.GrantModifications.Single(gm => gm.GrantModificationID == viewModel.GrantModificationID);
+            // Sanity check for alignment
+            Check.Ensure(relevantGrant.GrantID == grantModification.GrantID);
+            var grantAllocation = GrantAllocation.CreateNewBlank(grantModification);
+            viewModel.UpdateModel(grantAllocation, CurrentPerson);
+            grantAllocation.CreateAllGrantAllocationBudgetLineItemsByCostType();
+            SetMessageForDisplay($"{FieldDefinition.GrantAllocation.GetFieldDefinitionLabel()} \"{grantAllocation.GrantAllocationName}\" has been created.");
+            return new ModalDialogFormJsonResult();
+        }
+
+        [HttpGet]
         [GrantAllocationEditAsAdminFeature]
         public PartialViewResult NewGrantAllocationFiles(GrantAllocationPrimaryKey grantAllocationPrimaryKey)
         {

--- a/Source/ProjectFirma.Web/Controllers/GrantAllocationController.cs
+++ b/Source/ProjectFirma.Web/Controllers/GrantAllocationController.cs
@@ -184,9 +184,8 @@ namespace ProjectFirma.Web.Controllers
             Check.EnsureNotNull(originalGrantAllocation);
             var relevantGrant = originalGrantAllocation.GrantModification.Grant;
             
-            // Copy original grant allocation to new view model, except grant mod and allocation amount
+            // Copy original grant allocation to new view model, except for the allocation amount
             var viewModel = new EditGrantAllocationViewModel(originalGrantAllocation);
-            viewModel.GrantModificationID = 0;
             viewModel.AllocationAmount = null;
             viewModel.GrantAllocationName = $"{viewModel.GrantAllocationName} - Copy";
 

--- a/Source/ProjectFirma.Web/Models/GrantAllocationModelExtensions.cs
+++ b/Source/ProjectFirma.Web/Models/GrantAllocationModelExtensions.cs
@@ -52,6 +52,11 @@ namespace ProjectFirma.Web.Models
             return EditUrlTemplate.ParameterReplace(grantAllocation.GrantAllocationID);
         }
 
+        public static readonly UrlTemplate<int> DuplicateUrlTemplate = new UrlTemplate<int>(SitkaRoute<GrantAllocationController>.BuildUrlFromExpression(t => t.Duplicate(UrlTemplate.Parameter1Int)));
+        public static string GetDuplicateUrl(this GrantAllocation grantAllocation)
+        {
+            return DuplicateUrlTemplate.ParameterReplace(grantAllocation.GrantAllocationID);
+        }
 
         public static readonly UrlTemplate<int> NewNoteUrlTemplate = new UrlTemplate<int>(SitkaRoute<GrantAllocationController>.BuildUrlFromExpression(t => t.NewGrantAllocationNote(UrlTemplate.Parameter1Int)));
         public static string GetNewNoteUrl(this GrantAllocation grantAllocation)

--- a/Source/ProjectFirma.Web/Views/Grant/GrantAllocationGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Grant/GrantAllocationGridSpec.cs
@@ -61,6 +61,12 @@ namespace ProjectFirma.Web.Views.Grant
             {
                 Add(string.Empty, x => DhtmlxGridHtmlHelpers.MakeDeleteIconAndLinkBootstrap(x.GetDeleteUrl(), true, true), 30, DhtmlxGridColumnFilterType.None);
             }
+
+            if (userHasCreatePermissions)
+            {
+                Add(string.Empty, x => DhtmlxGridHtmlHelpers.MakeDuplicateIconAndLinkBootstrap(x.GetDuplicateUrl(), 950, "Duplicate Grant Allocation"), 30, DhtmlxGridColumnFilterType.None);
+            }
+
             Add(Models.FieldDefinition.GrantNumber.ToGridHeaderString(), x => x.GrantModification.Grant.GrantNumber, GrantNumberColumnWidth, DhtmlxGridColumnFilterType.SelectFilterStrict);
             Add(Models.FieldDefinition.GrantAllocationName.ToGridHeaderString(), x => UrlTemplate.MakeHrefString(x.GetDetailUrl(), x.GrantAllocationName), 250, DhtmlxGridColumnFilterType.Text);
             Add(Models.FieldDefinition.GrantModification.ToGridHeaderString(), x => UrlTemplate.MakeHrefString(x.GrantModification.GetDetailUrl(), x.GrantModification.GrantModificationName), 250, DhtmlxGridColumnFilterType.Text);


### PR DESCRIPTION
Add duplicate button to grant allocation grids to allow quickly
creating new grant allocation with editor fields pre-populated
from an existing grant allocation.