### PR TITLE
WADNR-1922 Update access to pages for anonymous users

### DIFF
--- a/Source/ProjectFirma.Web/Security/FirmaBaseFeature.cs
+++ b/Source/ProjectFirma.Web/Security/FirmaBaseFeature.cs
@@ -67,11 +67,24 @@ namespace ProjectFirma.Web.Security
 
         public virtual bool HasPermissionByPerson(Person person)
         {
-            if (!_grantedRoles.Any()) // AnonymousUnclassifiedFeature case
+            //AnonymousUnclassifiedFeature case; no roles on feature
+            if (!_grantedRoles.Any()) 
             {
-                return true; 
+                return true;
             }
-            return person != null && person.PersonID != Person.AnonymousPersonID && _grantedRoles.Any(x => person.HasRoleID(x.RoleID));
+
+            //Anonymous/Unassigned user + Unassigned role on feature
+            if (person != null
+                && person.IsAnonymousOrUnassigned 
+                && _grantedRoles.Contains(Role.Unassigned)) 
+            {
+                return true;
+            }
+
+            //Otherwise check if non-anonymous user with any matching role
+            return person != null
+                   && !person.IsAnonymousUser
+                   && _grantedRoles.Any(x => person.HasRoleID(x.RoleID));
         }
 
         protected override bool AuthorizeCore(HttpContextBase httpContext)


### PR DESCRIPTION
- Added new case to FirmaBaseFeature for HasPermissionByPerson() for anonymous/unassigned case + Role.Unassigned

--Can you take a look to see if I'm on the right track for this? I didn't realize the noted pages were "CustomPage" entries at first, but the change I made appears to fix them.