### PR TITLE
WADNR-1991_External_Reference_Layers_cause_Find_Your_Forester_admin_p…

### DIFF
--- a/Source/ProjectFirma.Web/ScriptsCustom/Maps/ProjectFirmaMaps.js
+++ b/Source/ProjectFirma.Web/ScriptsCustom/Maps/ProjectFirmaMaps.js
@@ -70,22 +70,25 @@ ProjectFirmaMaps.Map = function (mapInitJson, initialBaseLayerShown, treatAllLay
         streetLayerGroup.addTo(this.map);
     }
 
-    // Add external tile layers from ArcGIS Online
-    for (var i = 0; i < mapInitJson.ExternalMapLayers.length; ++i) {
-        var layerConfig = mapInitJson.ExternalMapLayers[i];
-        if (layerConfig.IsTiledMapService) {
-            this.addTiledLayerFromAGOL(layerConfig, overlayLayers);
-        }
-    }
-
     // add vector layers
     this.vectorLayers = [];
 
-    // Add external vector layers from ArcGIS Online 
-    for (var i = 0; i < mapInitJson.ExternalMapLayers.length; ++i) {
-        var layerConfig = mapInitJson.ExternalMapLayers[i];
-        if (!layerConfig.IsTiledMapService) {
-            this.addVectorLayerFromAGOL(layerConfig, overlayLayers);
+
+    if (!treatAllLayersAsBaseLayers) {//ArcGIS layers should not be added to the Manage Find Your Forester Page
+        //Add external tile layers from ArcGIS Online
+        for (var i = 0; i < mapInitJson.ExternalMapLayers.length; ++i) {
+            var layerConfig = mapInitJson.ExternalMapLayers[i];
+            if (layerConfig.IsTiledMapService) {
+                this.addTiledLayerFromAGOL(layerConfig, overlayLayers);
+            }
+        }
+
+        //Add external vector layers from ArcGIS Online
+        for (var i = 0; i < mapInitJson.ExternalMapLayers.length; ++i) {
+            var layerConfig = mapInitJson.ExternalMapLayers[i];
+            if (!layerConfig.IsTiledMapService) {
+                this.addVectorLayerFromAGOL(layerConfig, overlayLayers);
+            }
         }
     }
 


### PR DESCRIPTION
…age_to_crash

Adding code to prevent arcgis layers/vectors from being added to maps that treatAllLayersAsBaseLayers, i.e. the manage find your forester page