### PR TITLE
WADNR-2049 Add "Project Theme Notes" column to Project Theme detail page

### DIFF
--- a/Source/ProjectFirma.Web/Controllers/ClassificationController.cs
+++ b/Source/ProjectFirma.Web/Controllers/ClassificationController.cs
@@ -164,7 +164,7 @@ namespace ProjectFirma.Web.Controllers
         [PerformanceMeasureViewFeature]
         public GridJsonNetJObjectResult<Project> ProjectsGridJsonData(ClassificationPrimaryKey classificationPrimaryKey)
         {
-            var gridSpec = new BasicProjectInfoGridSpec(CurrentPerson, false);
+            var gridSpec = new ProjectThemeProjectListGridSpec(classificationPrimaryKey);
             var projectClassifications = classificationPrimaryKey.EntityObject.GetAssociatedProjects(CurrentPerson);
             var gridJsonNetJObjectResult = new GridJsonNetJObjectResult<Project>(projectClassifications, gridSpec);
             return gridJsonNetJObjectResult;

--- a/Source/ProjectFirma.Web/ProjectFirma.Web.csproj
+++ b/Source/ProjectFirma.Web/ProjectFirma.Web.csproj
@@ -1312,6 +1312,7 @@
     <Compile Include="Views\PriorityLandscape\EditPriorityLandscapeAboveMapTextViewModel.cs" />
     <Compile Include="Views\ProjectInvoice\ProjectInvoiceDetail.cs" />
     <Compile Include="Views\ProjectInvoice\ProjectInvoiceDetailViewData.cs" />
+    <Compile Include="Views\Project\ProjectThemeProjectListGridSpec.cs" />
     <Compile Include="Views\Reports\Edit.cs" />
     <Compile Include="Views\Reports\EditViewData.cs" />
     <Compile Include="Views\Reports\EditViewModel.cs" />

--- a/Source/ProjectFirma.Web/Views/Classification/Detail.cshtml
+++ b/Source/ProjectFirma.Web/Views/Classification/Detail.cshtml
@@ -111,7 +111,7 @@ Source code is available upon request via <support@sitkatech.com>.
                 <h2>@FieldDefinition.Project.GetFieldDefinitionLabelPluralized()</h2>
             </div>
             <div class="panel-body">
-                @Html.DhtmlxGrid(ViewDataTyped.BasicProjectInfoGridSpec, ViewDataTyped.BasicProjectInfoGridName, ViewDataTyped.BasicProjectInfoGridDataUrl, "height:300px", DhtmlxGridResizeType.VerticalResizableHorizontalAutoFit)
+                @Html.DhtmlxGrid(ViewDataTyped.ProjectThemeProjectListGridSpec, ViewDataTyped.ProjectThemeProjectListGridName, ViewDataTyped.ProjectThemeProjectListGridDataUrl, "height:300px", DhtmlxGridResizeType.VerticalResizableHorizontalAutoFit)
             </div>
         </div>
     </div>

--- a/Source/ProjectFirma.Web/Views/Classification/DetailViewData.cs
+++ b/Source/ProjectFirma.Web/Views/Classification/DetailViewData.cs
@@ -34,9 +34,9 @@ namespace ProjectFirma.Web.Views.Classification
         public readonly string IndexUrl;
         public readonly bool UserHasClassificationManagePermissions;
 
-        public readonly BasicProjectInfoGridSpec BasicProjectInfoGridSpec;
-        public readonly string BasicProjectInfoGridName;
-        public readonly string BasicProjectInfoGridDataUrl;
+        public readonly ProjectThemeProjectListGridSpec ProjectThemeProjectListGridSpec;
+        public readonly string ProjectThemeProjectListGridName;
+        public readonly string ProjectThemeProjectListGridDataUrl;
 
         public readonly string ClassificationDisplayName;
         public readonly string ClassificationDisplayNamePluralized;
@@ -53,15 +53,15 @@ namespace ProjectFirma.Web.Views.Classification
             ClassificationDisplayNamePluralized = classification.ClassificationSystem.ClassificationSystemNamePluralized;
             ClassificationDisplayName = classification.ClassificationSystem.ClassificationSystemName;
 
-            BasicProjectInfoGridName = "geospatialAreaProjectListGrid";
-            BasicProjectInfoGridSpec = new BasicProjectInfoGridSpec(CurrentPerson, false)
+            ProjectThemeProjectListGridName = "geospatialAreaProjectListGrid";
+            ProjectThemeProjectListGridSpec = new ProjectThemeProjectListGridSpec(Classification)
             {
                 ObjectNameSingular = $"{Models.FieldDefinition.Project.GetFieldDefinitionLabel()} associated with the {ClassificationDisplayName} {classification.DisplayName}",
                 ObjectNamePlural = $"{Models.FieldDefinition.Project.GetFieldDefinitionLabelPluralized()} associated with the {ClassificationDisplayName} {classification.DisplayName}",
                 SaveFiltersInCookie = true
             };
 
-            BasicProjectInfoGridDataUrl = SitkaRoute<ClassificationController>.BuildUrlFromExpression(tc => tc.ProjectsGridJsonData(classification));
+            ProjectThemeProjectListGridDataUrl = SitkaRoute<ClassificationController>.BuildUrlFromExpression(tc => tc.ProjectsGridJsonData(classification));
         }
     }
 }

--- a/Source/ProjectFirma.Web/Views/Project/ProjectThemeProjectListGridSpec.cs
+++ b/Source/ProjectFirma.Web/Views/Project/ProjectThemeProjectListGridSpec.cs
@@ -1,0 +1,55 @@
+﻿/*-----------------------------------------------------------------------
+<copyright file="BasicProjectInfoGridSpec.cs" company="Tahoe Regional Planning Agency and Environmental Science Associates">
+Copyright (c) Tahoe Regional Planning Agency and Environmental Science Associates. All rights reserved.
+<author>Environmental Science Associates</author>
+</copyright>
+
+<license>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License <http://www.gnu.org/licenses/> for more details.
+
+Source code is available upon request via <support@sitkatech.com>.
+</license>
+-----------------------------------------------------------------------*/
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using ProjectFirma.Web.Controllers;
+using ProjectFirma.Web.Security;
+using ProjectFirma.Web.Models;
+using LtInfo.Common;
+using LtInfo.Common.DhtmlWrappers;
+using LtInfo.Common.HtmlHelperExtensions;
+using LtInfo.Common.Views;
+using ProjectFirma.Web.Common;
+
+namespace ProjectFirma.Web.Views.Project
+{
+    public class ProjectThemeProjectListGridSpec : GridSpec<Models.Project>
+    {
+        public ProjectThemeProjectListGridSpec(ClassificationPrimaryKey classificationPrimaryKey)
+        {
+            Add(string.Empty, x => UrlTemplate.MakeHrefString(x.GetFactSheetUrl(), FirmaDhtmlxGridHtmlHelpers.FactSheetIcon.ToString()), 30, DhtmlxGridColumnFilterType.None);
+            Add(Models.FieldDefinition.FhtProjectNumber.ToGridHeaderString(), x => UrlTemplate.MakeHrefString(x.GetDetailUrl(), x.FhtProjectNumber), 100, DhtmlxGridColumnFilterType.Text);
+            Add(Models.FieldDefinition.ProjectName.ToGridHeaderString(), x => UrlTemplate.MakeHrefString(x.GetDetailUrl(), x.ProjectName), 300, DhtmlxGridColumnFilterType.Html);
+            
+            if (MultiTenantHelpers.HasCanStewardProjectsOrganizationRelationship())
+            {
+                Add(Models.FieldDefinition.ProjectsStewardOrganizationRelationshipToProject.ToGridHeaderString(), x => x.GetCanStewardProjectsOrganization().GetShortNameAsUrl(), 150,
+                    DhtmlxGridColumnFilterType.Html);
+            }
+            Add(Models.FieldDefinition.PrimaryContactOrganization.ToGridHeaderString(), x => x.GetPrimaryContactOrganization().GetShortNameAsUrl(), 150, DhtmlxGridColumnFilterType.Html);
+            Add(Models.FieldDefinition.ProjectStage.ToGridHeaderString(), x => x.ProjectStage.ProjectStageDisplayName, 90, DhtmlxGridColumnFilterType.SelectFilterStrict);
+            Add(Models.FieldDefinition.ProjectInitiationDate.ToGridHeaderString(), x => x.GetPlannedDate(), 90, DhtmlxGridColumnFilterType.SelectFilterStrict);
+            Add("Project Theme Notes", x => x.ProjectClassifications.FirstOrDefault(c => c.ClassificationID == classificationPrimaryKey.PrimaryKeyValue)?.ProjectClassificationNotes, 300, DhtmlxGridColumnFilterType.Text);
+        }
+    }
+}


### PR DESCRIPTION
Hrm; it seems that these are "Classifications" in the code, but "Themes" in the UI. Should I name the new grid spec "Project**Classification**ProjectListGridSpec" instead?