### PR TITLE
Pipeline: pass projectName + imageNames to docker-template

### DIFF
--- a/Build/azure-pipelines.yml
+++ b/Build/azure-pipelines.yml
@@ -97,8 +97,9 @@ stages:
         SecretsFilter: '*'
         RunAsPreJob: true
 
-    - template: azure-pipelines/templates/docker/docker-template.yml@BuildTemplates 
+    - template: azure-pipelines/templates/docker/docker-template.yml@BuildTemplates
       parameters:
+        projectName: 'wadnr'
         displayName: 'API'
         subscription: '$(azureSubscription)'
         containerRegistry: '$(kv-containerRegistry)'
@@ -107,6 +108,10 @@ stages:
         additionalImageTags: |
           $(Build.BuildNumber)-$(environment)
         includeLatestTag: true
+        imageNames:
+          - wadnr/api
+          - wadnr/scalar
+          - wadnr/gdalapi
 
 
   - job: BuildWeb
@@ -125,8 +130,9 @@ stages:
         SecretsFilter: '*'
         RunAsPreJob: true
 
-    - template: azure-pipelines/templates/docker/docker-template.yml@BuildTemplates 
+    - template: azure-pipelines/templates/docker/docker-template.yml@BuildTemplates
       parameters:
+        projectName: 'wadnr'
         displayName: 'Web'
         subscription: '$(azureSubscription)'
         containerRegistry: '$(kv-containerRegistry)'
@@ -135,6 +141,8 @@ stages:
         additionalImageTags: |
           $(Build.BuildNumber)-$(environment)
         includeLatestTag: true
+        imageNames:
+          - wadnr/web
 
 - stage: BuildTerraform
   displayName: Terraform Plan


### PR DESCRIPTION
## Summary
- Wires Microsoft Defender for Cloud per-image container scans into the API and Web build jobs by passing `imageNames` to the updated `docker-template.yml@BuildTemplates`.
- Also sets the now-required `projectName: 'wadnr'` on both template calls (matches the `wadnr/` image prefix and the `wadnr` helm release).

## Context
BuildTemplates' `docker-template` now emits one `MicrosoftSecurityDevOps@1` (Trivy) scan per `imageName` at compile time — feeding Defender for Cloud and the ADO Scans tab. Without `imageNames` it falls back to scanning only the first compose image discovered at runtime. Listing every image here ensures full coverage.

`imageNames` values match the compose `image:` declarations and the repositories already referenced in the helm `overrideValues`:
- API compose (`docker-compose/docker-compose.yml`): `wadnr/api`, `wadnr/scalar`, `wadnr/gdalapi`
- Web compose (`WADNR.Web/docker-compose/docker-compose.yml`): `wadnr/web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)