### PR TITLE
Enable response compression (Brotli + Gzip Optimal)

### DIFF
--- a/WADNR.API/Startup.cs
+++ b/WADNR.API/Startup.cs
@@ -8,6 +8,7 @@ using WADNR.EFModels.Entities;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,6 +18,8 @@ using NetTopologySuite.IO.Converters;
 using SendGrid;
 using Serilog;
 using System;
+using System.IO.Compression;
+using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -62,6 +65,16 @@ namespace WADNR.API
                 options.JsonSerializerOptions.PropertyNamingPolicy = null;
                 options.JsonSerializerOptions.NumberHandling = JsonNumberHandling.AllowReadingFromString;
             });
+
+            services.AddResponseCompression(options =>
+            {
+                options.EnableForHttps = true;
+                options.Providers.Add<BrotliCompressionProvider>();
+                options.Providers.Add<GzipCompressionProvider>();
+                options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(new[] { "application/json" });
+            });
+            services.Configure<BrotliCompressionProviderOptions>(options => options.Level = CompressionLevel.Optimal);
+            services.Configure<GzipCompressionProviderOptions>(options => options.Level = CompressionLevel.Optimal);
 
             services.Configure<WADNRConfiguration>(Configuration);
             services.Configure<SendGridConfiguration>(Configuration);
@@ -227,6 +240,7 @@ namespace WADNR.API
                 app.UseHsts();
             }
             app.UseHttpsRedirection();
+            app.UseResponseCompression();
             app.UseRouting();
             app.UseCors(policy =>
             {

--- a/WADNR.GDALAPI/Program.cs
+++ b/WADNR.GDALAPI/Program.cs
@@ -1,3 +1,5 @@
+using System.IO.Compression;
+using Microsoft.AspNetCore.ResponseCompression;
 using WADNR.GDALAPI.Services;
 using Serilog;
 using Serilog.Core;
@@ -11,6 +13,17 @@ var logger = CreateSerilogLogger(builder);
 builder.Host.UseSerilog(logger);
 
 builder.Services.AddControllers();
+
+builder.Services.AddResponseCompression(options =>
+{
+    options.EnableForHttps = true;
+    options.Providers.Add<BrotliCompressionProvider>();
+    options.Providers.Add<GzipCompressionProvider>();
+    options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(new[] { "application/json" });
+});
+builder.Services.Configure<BrotliCompressionProviderOptions>(options => options.Level = CompressionLevel.Optimal);
+builder.Services.Configure<GzipCompressionProviderOptions>(options => options.Level = CompressionLevel.Optimal);
+
 builder.Services.AddScoped<Ogr2OgrService>();
 builder.Services.AddScoped<OgrInfoService>();
 
@@ -23,6 +36,8 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
+
+app.UseResponseCompression();
 
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
## Summary
- Adds `Microsoft.AspNetCore.ResponseCompression` to `WADNR.API` and `WADNR.GDALAPI`
- Brotli + Gzip providers (browsers prefer Brotli; Gzip is the universal fallback)
- Compression level set to `Optimal` — small server CPU cost for ~30% smaller output vs `Fastest`

Cribbed from the same change on Qanat ([esassoc/qanat@753b0b7](https://github.com/esassoc/qanat/commit/753b0b70986667637b3c2776773496381599317b)), which measured ~10× smaller JSON payloads on the worst-case page. Production gains scale with network bandwidth savings on every endpoint with a non-trivial response and should also cut Azure egress costs.

## Test plan
- [ ] Smoke-test a heavy endpoint locally and confirm `Content-Encoding: br` (or `gzip`) on the response
- [ ] Verify swagger UI and health checks still load
- [ ] Sanity-check GDALAPI controllers still respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)