### PR TITLE
Fix GDAL API Docker build: broken Arrow apt repo + oversized build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,9 @@
 **/node_modules
 **/npm-debug.log
 **/obj
+**/*.bacpac
+**/*.bak
+Build/temp
 **/secrets.dev.yaml
 **/values.dev.yaml
 LICENSE

--- a/WADNR.GDALAPI/Dockerfile
+++ b/WADNR.GDALAPI/Dockerfile
@@ -2,7 +2,11 @@ FROM ghcr.io/osgeo/gdal:ubuntu-full-3.8.5 as base
 WORKDIR /app
 EXPOSE 8080
 
-RUN apt-get update && \
+# The GDAL base image ships an Apache Arrow apt repo whose GPG signing key
+# rotates and breaks `apt-get update`. We don't use it (Arrow is already in the
+# image), so remove it before updating.
+RUN rm -f /etc/apt/sources.list.d/apache-arrow.sources && \
+    apt-get update && \
     apt-get install -y wget
 
 RUN wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
@@ -22,7 +26,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY ["WADNR.GDALAPI/WADNR.GDALAPI.csproj", "WADNR.GDALAPI/"]
 RUN dotnet restore "WADNR.GDALAPI/WADNR.GDALAPI.csproj"
-COPY . .
+COPY WADNR.GDALAPI/ WADNR.GDALAPI/
 WORKDIR "/src/WADNR.GDALAPI"
 RUN dotnet build "WADNR.GDALAPI.csproj" -c Release -o /app/build
 


### PR DESCRIPTION
## Problem

The pipeline build of `wadnr/gdalapi` fails in the base stage:

```
E: The repository 'https://apache.jfrog.io/artifactory/arrow/ubuntu jammy InRelease' is not signed.
NO_PUBKEY 9E922B2D60E9FD1C
```

The GDAL base image (`ghcr.io/osgeo/gdal:ubuntu-full-3.8.5`) ships an Apache Arrow apt repo (`/etc/apt/sources.list.d/apache-arrow.sources`) whose GPG signing key has rotated. Any clean `apt-get update` in that stage is rejected. Local builds masked this by reusing **cached** base layers; the pipeline builds fresh, so it hits the wall.

While in here, the build context was also shipping **~3 GB every build** — `Build/temp/WADNRDB.bacpac` (the database export from `DatabaseDownload.ps1`) was not excluded by `.dockerignore`.

## Changes

1. **`WADNR.GDALAPI/Dockerfile`** — remove the unused, broken Arrow apt repo before the first `apt-get update`. Arrow is already baked into the image; we never install from that repo.
2. **`.dockerignore`** — exclude `**/*.bacpac`, `**/*.bak`, and `Build/temp`. Speeds up **all three** images that use the repo root as build context (API, Scalar, GDALAPI).
3. **`WADNR.GDALAPI/Dockerfile`** — narrow `COPY . .` → `COPY WADNR.GDALAPI/` since the project is self-contained (no `<ProjectReference>`s), improving layer caching.

## Verification

Reproduced the pipeline failure locally with `docker compose build --no-cache wadnr.gdalapi`, then confirmed the fix with a second full `--no-cache` build — completes clean (exit 0), `aspnetcore-runtime-10.0` installs, image assembles.

Build context transfer: **3.12 GB / ~202s → ~1 kB / 0.4s**.

## Out of scope (noted, not addressed)

- Pre-existing `as`/`FROM` casing lint on line 1 of the Dockerfile.
- `NU1903` high-severity advisory on `Microsoft.OpenApi` 2.3.0 (transitive via Swashbuckle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)