### PR TITLE
Raise API ingress request-timeout to 1200s to stop GIS bulk import 504s

### DIFF
--- a/charts/wadnr/values.yaml
+++ b/charts/wadnr/values.yaml
@@ -69,7 +69,7 @@ api:
       cert-manager.io/cluster-issuer: letsencrypt
       acme.cert-manager.io/http01-edit-in-place: "true"
       appgw.ingress.kubernetes.io/ssl-redirect: "true"
-      appgw.ingress.kubernetes.io/request-timeout: "300"
+      appgw.ingress.kubernetes.io/request-timeout: "1200"
       cert-manager.io/issue-temporary-certificate: "true"
       appgw.ingress.kubernetes.io/connection-draining: "true"
       appgw.ingress.kubernetes.io/connection-draining-timeout: "30"


### PR DESCRIPTION
## Problem

A tester in QA hit a **504 Gateway Timeout** on 2026-08-05 running a GIS Bulk Import of a 3,042-feature upload:

```
POST https://internalapi-wadnr.esa-qa.sitkatech.com/gis-bulk-import/attempts/6140/import
net::ERR_FAILED 504 (Gateway Time-out)
```

The browser also reports it as a CORS error — that's a red herring. Application Gateway's 504 response carries no `Access-Control-Allow-Origin` header, so the browser reports the missing header rather than the timeout.

The DevTools waterfall showed the request cut off at roughly 300s, which matches the AGIC backend HTTP setting on the api ingress exactly (and rules out App Gateway's 240s frontend idle timeout).

## Change

`charts/wadnr/values.yaml:72`, api ingress only:

```yaml
appgw.ingress.kubernetes.io/request-timeout: "300"   →   "1200"
```

This matches the value the `web` ingress already uses (line 128), so there's existing precedent that AGIC accepts it in this cluster. Well inside Application Gateway's valid 1–86400s range. The `scalar` ingress is untouched at 300.

## Scope — this fixes the symptom only

The import will no longer be killed by the gateway, but **treatments still will not import**. `procImportTreatmentsFromGisUploadAttempt` continues to hit the 180s EF `CommandTimeout` (`WADNR.API/Startup.cs:136`), and `EnableRetryOnFailure(maxRetryCount: 3)` on the next line retries it, so a single call can burn up to 4 × 180s = 720s.

With 1200s of headroom the request now completes and returns 200 with the failure surfaced as a warning (`validate-metadata-step.component.ts:258` renders `result.Warnings`) instead of a bare gateway timeout. That's a visible, actionable failure rather than an opaque one — but the user waits a long time for it.

Datadog shows 51 of these `CommandTimeout='180'` failures in the last 7 days across **both QA and prod**.

## Follow-ups (not in this PR)

1. Drop the retry for the proc call at `GisBulkImport.StaticHelpers.cs:726` and size `SetCommandTimeout` to the real workload — collapses worst case from ~720s to one honest attempt. `LoaUpload` and `ServiceForestryUpload` already set 400s for their bulk procs; GIS bulk import never did.
2. Move the import to Hangfire (already in the stack) so it isn't bounded by any request timeout.

## Deployment note

Ships on the next `helm upgrade wadnr` (`Build/azure-pipelines.yml:521`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)