### PR TITLE
Stop retrying the GIS treatment import proc and give it a real timeout

### DIFF
--- a/WADNR.API.Tests/Integration/GisTreatmentImportProcTests.cs
+++ b/WADNR.API.Tests/Integration/GisTreatmentImportProcTests.cs
@@ -1,0 +1,423 @@
+using System.Data.Common;
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO.Converters;
+using WADNR.API.Tests.Helpers;
+using WADNR.EFModels.Entities;
+using WADNR.Models.DataTransferObjects.GisBulkImport;
+
+namespace WADNR.API.Tests.Integration;
+
+/// <summary>
+/// Covers how ImportProjectsAsync invokes procImportTreatmentsFromGisUploadAttempt, after that call
+/// moved off ExecuteSqlInterpolatedAsync onto the underlying connection with an explicit 600s timeout.
+///
+/// These tests need a real SQL Server database, and that is the whole point of them. The existing
+/// <c>GisBulkImportArcGisIdTests</c> run on the InMemory provider, where
+/// <c>Database.GetDbConnection()</c> throws because the provider is not relational — and that throw
+/// lands in the same catch that turns proc failures into warnings. So on InMemory the treatment import
+/// is silently skipped, and those tests pass whether the proc call works or not.
+///
+/// That matters more than it sounds, because the failure mode here is invisible. A proc failure is
+/// caught and recorded as a warning on an otherwise successful 200 response, so an import that creates
+/// zero treatments looks like an import that worked. Switching to
+/// <c>CommandType.StoredProcedure</c> made that easier to trigger: parameters are now bound by name,
+/// so a typo or a renamed proc parameter produces "Procedure expects parameter which was not
+/// supplied" rather than being inert text inside an EXEC string.
+/// </summary>
+[TestClass]
+public class GisTreatmentImportProcTests
+{
+    /// <summary>Distinct identifier per feature, so each becomes its own project with one treatment.</summary>
+    private const int FeatureCount = 3;
+
+    private int _programID;
+    private int _sourceOrganizationID;
+    private int _attemptID;
+
+    [TestCleanup]
+    public async Task TearDown()
+    {
+        if (_attemptID == 0)
+        {
+            return;
+        }
+
+        await using var dbContext = NewContext();
+        await TearDownFixtureAsync(dbContext);
+        _attemptID = 0;
+    }
+
+    #region Tests
+
+    [TestMethod]
+    public async Task ImportProjects_CreatesTreatmentsAndReportsNoWarnings_WhenProcRunsAgainstRealSql()
+    {
+        await using var dbContext = NewContext();
+        var request = await ArrangeAsync(dbContext);
+
+        var result = await GisBulkImports.ImportProjectsAsync(dbContext, _attemptID, request);
+
+        // The load-bearing assertion. Everything the proc can go wrong with — a bad parameter name, a
+        // type mismatch, a renamed proc — surfaces here and nowhere else, because the catch around the
+        // call converts it into a warning instead of a failure.
+        Assert.AreEqual(0, result.Warnings.Count,
+            "The treatment import proc reported a problem, which an import would otherwise swallow into " +
+            $"a successful 200 response: {string.Join(" | ", result.Warnings)}");
+
+        Assert.AreEqual(FeatureCount, result.ProjectsCreated, "Expected one project per distinct identifier.");
+
+        // Warnings being empty only proves nothing threw. Treatments actually existing proves the proc
+        // ran and did its work.
+        var projectIDs = await ProjectIDsForAttemptAsync(dbContext);
+        var treatmentCount = await dbContext.Treatments.CountAsync(t => projectIDs.Contains(t.ProjectID));
+        Assert.AreEqual(FeatureCount, treatmentCount,
+            "The proc completed without error but created no treatments, so the import silently did nothing.");
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_RunsProcOutsideEntityFramework_SoTheRetryingExecutionStrategyCannotApply()
+    {
+        // Why this is worth asserting: EF is configured with EnableRetryOnFailure(maxRetryCount: 3) and
+        // SQL timeouts are classed transient, so running the proc through EF meant a slow import was
+        // executed up to four times — 4 x CommandTimeout before the caller saw anything, which is what
+        // produced the 504. Running it on the raw connection is what removes the execution strategy
+        // from the path.
+        //
+        // This asserts the bypass, not the attempt count. Counting attempts is impossible from outside:
+        // the command never reaches EF, so no interceptor can see it, and the timeout is a private
+        // const. Proving the command is absent from EF is the strongest observation available without
+        // adding a seam to production code for the test's benefit.
+        var interceptor = new CommandTextRecordingInterceptor();
+        await using var dbContext = NewContext(interceptor);
+        var request = await ArrangeAsync(dbContext);
+
+        interceptor.Reset();
+        var result = await GisBulkImports.ImportProjectsAsync(dbContext, _attemptID, request);
+
+        Assert.AreEqual(0, result.Warnings.Count,
+            $"Import reported warnings, so this test would be measuring a failed proc: {string.Join(" | ", result.Warnings)}");
+
+        var procCommands = interceptor.CommandTexts
+            .Where(x => x.Contains("procImportTreatmentsFromGisUploadAttempt", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        Assert.AreEqual(0, procCommands.Count,
+            "The proc was executed through EF, which puts it back under the retrying execution strategy — " +
+            "the exact configuration that turned one slow import into four and caused the 504. " +
+            $"Observed: {string.Join(" | ", procCommands)}");
+
+        // Two negative controls, without which the assertion above passes for the wrong reason. The
+        // interceptor must be wired up and seeing traffic, and the proc must genuinely have run — an
+        // import that skipped the proc entirely would also show zero proc commands.
+        Assert.IsTrue(interceptor.CommandTexts.Count > 0,
+            "The interceptor recorded no commands at all, so its silence about the proc proves nothing.");
+
+        var projectIDs = await ProjectIDsForAttemptAsync(dbContext);
+        var treatmentCount = await dbContext.Treatments.CountAsync(t => projectIDs.Contains(t.ProjectID));
+        Assert.AreEqual(FeatureCount, treatmentCount,
+            "No treatments were created, so the proc did not run and its absence from EF is meaningless.");
+    }
+
+    #endregion
+
+    #region Fixture
+
+    private static WADNRDbContext NewContext(IInterceptor? interceptor = null)
+    {
+        var connectionString = AssemblySteps.Configuration["sqlConnectionString"]
+            ?? throw new InvalidOperationException("sqlConnectionString not found in environment.json");
+
+        // Mirrors production, including EnableRetryOnFailure — the retrying execution strategy is the
+        // thing under test, so configuring it away would make the second test vacuous.
+        var builder = new DbContextOptionsBuilder<WADNRDbContext>()
+            .UseSqlServer(connectionString, x =>
+            {
+                x.UseNetTopologySuite();
+                x.EnableRetryOnFailure(maxRetryCount: 3, maxRetryDelay: TimeSpan.FromSeconds(5), errorNumbersToAdd: null);
+            });
+
+        if (interceptor != null)
+        {
+            builder.AddInterceptors(interceptor);
+        }
+
+        return new WADNRDbContext(builder.Options, AssemblySteps.AuditUserProvider);
+    }
+
+    /// <summary>
+    /// Seeds Program + source org + attempt, then stages features through the real upload path and
+    /// returns the import request.
+    ///
+    /// The features are staged by calling <c>UploadAndProcessFileAsync</c> rather than by hand-inserting
+    /// GisFeature rows, because that is what creates the GisMetadataAttribute and
+    /// GisUploadAttemptGisMetadataAttribute rows the proc joins through. Hand-seeding those is where a
+    /// fixture quietly stops resembling production.
+    /// </summary>
+    private async Task<GisBulkImportRequest> ArrangeAsync(WADNRDbContext dbContext)
+    {
+        var program = await ProgramHelper.CreateProgramAsync(
+            dbContext, AssemblySteps.TestAdminPersonID, name: $"GIS Treatment Proc Test {DateTime.UtcNow:yyyyMMddHHmmssfff}");
+        _programID = program.ProgramID;
+
+        var organizationID = (await dbContext.Organizations.AsNoTracking().OrderBy(x => x.OrganizationID).FirstAsync()).OrganizationID;
+        var relationshipTypeID = (await dbContext.RelationshipTypes.AsNoTracking().OrderBy(x => x.RelationshipTypeID).FirstAsync()).RelationshipTypeID;
+        var projectTypeName = (await dbContext.ProjectTypes.AsNoTracking().OrderBy(x => x.ProjectTypeID).FirstAsync()).ProjectTypeName;
+
+        var sourceOrganization = new GisUploadSourceOrganization
+        {
+            GisUploadSourceOrganizationName = $"Treatment Proc Test Source {program.ProgramID}",
+            ProgramID = program.ProgramID,
+            ProjectStageDefaultID = (int)ProjectStageEnum.Implementation,
+            ProjectTypeDefaultName = projectTypeName,
+            TreatmentTypeDefaultName = null,
+            DefaultLeadImplementerOrganizationID = organizationID,
+            RelationshipTypeForDefaultOrganizationID = relationshipTypeID,
+            AdjustProjectTypeBasedOnTreatmentTypes = false,
+            DataDeriveProjectStage = false,
+            ImportAsDetailedLocationInsteadOfTreatments = false,
+            ImportAsDetailedLocationInAdditionToTreatments = false,
+            ApplyStartDateToProject = true,
+            ApplyCompletedDateToProject = true,
+            ApplyStartDateToTreatments = true,
+            ApplyEndDateToTreatments = true,
+            ImportIsFlattened = false,
+            ProjectDescriptionDefaultText = "Created by GisTreatmentImportProcTests."
+        };
+        dbContext.GisUploadSourceOrganizations.Add(sourceOrganization);
+        await dbContext.SaveChangesWithNoAuditingAsync();
+        _sourceOrganizationID = sourceOrganization.GisUploadSourceOrganizationID;
+
+        var attempt = new GisUploadAttempt
+        {
+            GisUploadSourceOrganizationID = sourceOrganization.GisUploadSourceOrganizationID,
+            GisUploadAttemptCreatePersonID = AssemblySteps.TestAdminPersonID,
+            GisUploadAttemptCreateDate = new DateTime(2026, 8, 6, 0, 0, 0, DateTimeKind.Utc)
+        };
+        dbContext.GisUploadAttempts.Add(attempt);
+        await dbContext.SaveChangesWithNoAuditingAsync();
+        _attemptID = attempt.GisUploadAttemptID;
+
+        await GisBulkImports.UploadAndProcessFileAsync(dbContext, _attemptID, BuildGeoJson());
+
+        return await BuildRequestAsync(dbContext, _attemptID);
+    }
+
+    /// <summary>
+    /// Field names and value shapes follow the DNR State Lands export, which is what the proc's acreage
+    /// and treatment-type branches were written against.
+    /// </summary>
+    private static string BuildGeoJson()
+    {
+        var featureCollection = new FeatureCollection();
+        var factory = new GeometryFactory(new PrecisionModel(), 4326);
+
+        for (var i = 0; i < FeatureCount; i++)
+        {
+            // Small squares inside Washington so they intersect real County / DNRUplandRegion /
+            // PriorityLandscape geometry, matching what a real upload does.
+            var minX = -122.0 + i * 0.05;
+            var minY = 46.5;
+            const double size = 0.02;
+
+            var geometry = factory.CreatePolygon(factory.CreateLinearRing(
+            [
+                new Coordinate(minX, minY),
+                new Coordinate(minX, minY + size),
+                new Coordinate(minX + size, minY + size),
+                new Coordinate(minX + size, minY),
+                new Coordinate(minX, minY)
+            ]));
+
+            featureCollection.Add(new Feature(geometry, new AttributesTable
+            {
+                { "FMA_ID", 9_100_000 + i },
+                { "FMA_NM", $"TREATMENT PROC TEST UNIT {i}" },
+                { "FMA_TYPE_C", "THIN" },
+                { "TECHNIQUE_", "PCT" },
+                { "ACRES_TREA", Math.Round(12.5 + i, 2) },
+                { "STAND_ORIG", IsoDate(2020, 4, 28, i) },
+                { "FMA_DT", IsoDate(2021, 5, 12, i) }
+            }));
+        }
+
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new GeoJsonConverterFactory());
+        return JsonSerializer.Serialize(featureCollection, options);
+    }
+
+    private static string IsoDate(int year, int month, int day, int index) =>
+        new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc)
+            .AddDays(index)
+            .ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Builds the request from the metadata attributes the upload stage registered. Names are looked up
+    /// lowercased because UploadAndProcessFileAsync stores them via ToLowerInvariant.
+    ///
+    /// The treatment-related mappings are all supplied deliberately: with them null the proc receives
+    /// -1 sentinels, creates nothing, and both tests would pass while proving nothing.
+    /// </summary>
+    private static async Task<GisBulkImportRequest> BuildRequestAsync(WADNRDbContext dbContext, int attemptID)
+    {
+        var attributeIDByName = await dbContext.GisUploadAttemptGisMetadataAttributes
+            .AsNoTracking()
+            .Where(x => x.GisUploadAttemptID == attemptID)
+            .Select(x => new { x.GisMetadataAttributeID, x.GisMetadataAttribute.GisMetadataAttributeName })
+            .ToDictionaryAsync(x => x.GisMetadataAttributeName, x => x.GisMetadataAttributeID, StringComparer.OrdinalIgnoreCase);
+
+        int Required(string name) => attributeIDByName.TryGetValue(name, out var id)
+            ? id
+            : throw new InvalidOperationException(
+                $"Expected metadata attribute '{name}' on attempt {attemptID}. Present: {string.Join(", ", attributeIDByName.Keys)}");
+
+        return new GisBulkImportRequest
+        {
+            ProjectIdentifierMetadataAttributeID = Required("fma_id"),
+            ProjectNameMetadataAttributeID = Required("fma_nm"),
+            StartDateMetadataAttributeID = Required("stand_orig"),
+            CompletionDateMetadataAttributeID = Required("fma_dt"),
+            TreatmentTypeMetadataAttributeID = Required("fma_type_c"),
+            TreatmentDetailedActivityTypeMetadataAttributeID = Required("technique_"),
+            FootprintAcresMetadataAttributeID = Required("acres_trea"),
+            TreatedAcresMetadataAttributeID = Required("acres_trea")
+        };
+    }
+
+    private async Task<List<int>> ProjectIDsForAttemptAsync(WADNRDbContext dbContext) =>
+        await dbContext.Projects
+            .AsNoTracking()
+            .Where(p => p.CreateGisUploadAttemptID == _attemptID || p.LastUpdateGisUploadAttemptID == _attemptID)
+            .Select(p => p.ProjectID)
+            .ToListAsync();
+
+    /// <summary>
+    /// Removes everything the fixture and the import created. Children before parents, and treatments
+    /// are scoped by ProjectID rather than ProgramID so rows the proc wrote are caught even though it
+    /// does not stamp ProgramID.
+    /// </summary>
+    private async Task TearDownFixtureAsync(WADNRDbContext dbContext)
+    {
+        dbContext.ChangeTracker.Clear();
+
+        var projectIDs = await ProjectIDsForAttemptAsync(dbContext);
+        if (projectIDs.Count > 0)
+        {
+            await dbContext.Treatments.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectLocations.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectCounties.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectRegions.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectPriorityLandscapes.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectPrograms.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectOrganizations.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.Projects.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+        }
+
+        var featureIDsQuery = dbContext.GisFeatures
+            .Where(f => f.GisUploadAttemptID == _attemptID)
+            .Select(f => f.GisFeatureID);
+
+        await dbContext.GisFeatureMetadataAttributes.Where(x => featureIDsQuery.Contains(x.GisFeatureID)).ExecuteDeleteAsync();
+        await dbContext.GisFeatures.Where(x => x.GisUploadAttemptID == _attemptID).ExecuteDeleteAsync();
+        await dbContext.GisUploadAttemptGisMetadataAttributes.Where(x => x.GisUploadAttemptID == _attemptID).ExecuteDeleteAsync();
+        await dbContext.GisUploadAttempts.Where(x => x.GisUploadAttemptID == _attemptID).ExecuteDeleteAsync();
+
+        if (_sourceOrganizationID != 0)
+        {
+            await dbContext.GisUploadSourceOrganizations
+                .Where(x => x.GisUploadSourceOrganizationID == _sourceOrganizationID).ExecuteDeleteAsync();
+        }
+
+        if (_programID != 0)
+        {
+            await dbContext.Programs.Where(x => x.ProgramID == _programID).ExecuteDeleteAsync();
+        }
+
+        // GisMetadataAttribute rows are shared global data the production code only ever adds to, so
+        // they are deliberately left alone.
+        dbContext.ChangeTracker.Clear();
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Records the text of every command EF sends. Used as evidence of absence: the treatment proc must
+    /// not appear here, because appearing here would mean it is running under the retrying execution
+    /// strategy again.
+    /// </summary>
+    private sealed class CommandTextRecordingInterceptor : DbCommandInterceptor
+    {
+        private readonly List<string> _commandTexts = [];
+        private readonly object _lock = new();
+
+        public IReadOnlyList<string> CommandTexts
+        {
+            get { lock (_lock) { return _commandTexts.ToList(); } }
+        }
+
+        public void Reset()
+        {
+            lock (_lock) { _commandTexts.Clear(); }
+        }
+
+        // Both the Executing and Failed hooks are recorded, not just the successful ones: a proc that
+        // ran through EF and then timed out is precisely the case being guarded against, and it would
+        // never reach an "executed" hook.
+        public override InterceptionResult<DbDataReader> ReaderExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Record(command);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result, CancellationToken cancellationToken = default)
+        {
+            Record(command);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        public override InterceptionResult<int> NonQueryExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
+        {
+            Record(command);
+            return base.NonQueryExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+        {
+            Record(command);
+            return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        public override InterceptionResult<object> ScalarExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<object> result)
+        {
+            Record(command);
+            return base.ScalarExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<object>> ScalarExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<object> result, CancellationToken cancellationToken = default)
+        {
+            Record(command);
+            return base.ScalarExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        public override void CommandFailed(DbCommand command, CommandErrorEventData eventData)
+        {
+            Record(command);
+            base.CommandFailed(command, eventData);
+        }
+
+        public override Task CommandFailedAsync(DbCommand command, CommandErrorEventData eventData, CancellationToken cancellationToken = default)
+        {
+            Record(command);
+            return base.CommandFailedAsync(command, eventData, cancellationToken);
+        }
+
+        private void Record(DbCommand command)
+        {
+            lock (_lock) { _commandTexts.Add(command.CommandText ?? ""); }
+        }
+    }
+}

--- a/WADNR.API/Controllers/GisBulkImportController.cs
+++ b/WADNR.API/Controllers/GisBulkImportController.cs
@@ -152,6 +152,17 @@ public class GisBulkImportController(
         try
         {
             var result = await GisBulkImports.ImportProjectsAsync(DbContext, gisUploadAttemptID, request);
+
+            // A partially successful import returns 200 with warnings, so without this the failure is
+            // visible to the user but invisible in Datadog — the only trace is a bare EF
+            // "Failed executing DbCommand" entry with no attempt ID on it.
+            if (result.Warnings?.Count > 0)
+            {
+                Logger.LogError(
+                    "Bulk import for GisUploadAttemptID {GisUploadAttemptID} completed with {WarningCount} warning(s): {Warnings}",
+                    gisUploadAttemptID, result.Warnings.Count, string.Join(" | ", result.Warnings));
+            }
+
             return Ok(result);
         }
         catch (Exception ex)

--- a/WADNR.EFModels/Entities/GisBulkImport.StaticHelpers.cs
+++ b/WADNR.EFModels/Entities/GisBulkImport.StaticHelpers.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using NetTopologySuite.Features;
@@ -9,6 +10,13 @@ namespace WADNR.EFModels.Entities;
 
 public static class GisBulkImports
 {
+    /// <summary>
+    /// Command timeout for the treatment import proc. The global default is 180s
+    /// (WADNR.API/Startup.cs), which large uploads exceed. Kept comfortably under the api ingress
+    /// request-timeout so the proc fails before Application Gateway drops the connection.
+    /// </summary>
+    private const int TreatmentImportCommandTimeoutSeconds = 600;
+
     public static async Task<List<GisUploadSourceOrganizationSummary>> ListSourceOrganizationsAsync(WADNRDbContext dbContext)
     {
         return await dbContext.GisUploadSourceOrganizations
@@ -723,38 +731,100 @@ public static class GisBulkImports
             // Null metadata attribute IDs use -1 sentinel for the proc
             int ToSqlID(int? id) => id ?? -1;
 
-            await dbContext.Database.ExecuteSqlInterpolatedAsync(
-                $@"EXEC dbo.procImportTreatmentsFromGisUploadAttempt
-                    @piGisUploadAttemptID = {gisUploadAttemptID},
-                    @projectIdentifierGisMetadataAttributeID = {request.ProjectIdentifierMetadataAttributeID},
-                    @footprintAcresMetadataAttributeID = {ToSqlID(request.FootprintAcresMetadataAttributeID)},
-                    @treatedAcresMetadataAttributeID = {ToSqlID(request.TreatedAcresMetadataAttributeID)},
-                    @treatmentTypeMetadataAttributeID = {ToSqlID(request.TreatmentTypeMetadataAttributeID)},
-                    @treatmentDetailedActivityTypeMetadataAttributeID = {ToSqlID(request.TreatmentDetailedActivityTypeMetadataAttributeID)},
-                    @treatmentTypeID = {treatmentTypeID},
-                    @treatmentDetailedActivityTypeID = {treatmentDetailedActivityTypeID},
-                    @isFlattened = {isFlattened},
-                    @pruningAcresMetadataAttributeID = {ToSqlID(request.PruningAcresMetadataAttributeID)},
-                    @thinningAcresMetadataAttributeID = {ToSqlID(request.ThinningAcresMetadataAttributeID)},
-                    @chippingAcresMetadataAttributeID = {ToSqlID(request.ChippingAcresMetadataAttributeID)},
-                    @masticationAcresMetadataAttributeID = {ToSqlID(request.MasticationAcresMetadataAttributeID)},
-                    @grazingAcresMetadataAttributeID = {ToSqlID(request.GrazingAcresMetadataAttributeID)},
-                    @lopScatterAcresMetadataAttributeID = {ToSqlID(request.LopScatAcresMetadataAttributeID)},
-                    @biomassRemovalAcresMetadataAttributeID = {ToSqlID(request.BiomassRemovalAcresMetadataAttributeID)},
-                    @handPileAcresMetadataAttributeID = {ToSqlID(request.HandPileAcresMetadataAttributeID)},
-                    @handPileBurnAcresMetadataAttributeID = {ToSqlID(request.HandPileBurnAcresMetadataAttributeID)},
-                    @machineBurnAcresMetadataAttributeID = {ToSqlID(request.MachinePileBurnAcresMetadataAttributeID)},
-                    @broadcastBurnAcresMetadataAttributeID = {ToSqlID(request.BroadcastBurnAcresMetadataAttributeID)},
-                    @otherBurnAcresMetadataAttributeID = {ToSqlID(request.OtherAcresMetadataAttributeID)},
-                    @startDateMetadataAttributeID = {ToSqlID(request.StartDateMetadataAttributeID)},
-                    @endDateMetadataAttributeID = {ToSqlID(request.CompletionDateMetadataAttributeID)}");
+            await ExecuteTreatmentImportProcAsync(dbContext, new Dictionary<string, int>
+            {
+                ["@piGisUploadAttemptID"] = gisUploadAttemptID,
+                ["@projectIdentifierGisMetadataAttributeID"] = request.ProjectIdentifierMetadataAttributeID,
+                ["@footprintAcresMetadataAttributeID"] = ToSqlID(request.FootprintAcresMetadataAttributeID),
+                ["@treatedAcresMetadataAttributeID"] = ToSqlID(request.TreatedAcresMetadataAttributeID),
+                ["@treatmentTypeMetadataAttributeID"] = ToSqlID(request.TreatmentTypeMetadataAttributeID),
+                ["@treatmentDetailedActivityTypeMetadataAttributeID"] = ToSqlID(request.TreatmentDetailedActivityTypeMetadataAttributeID),
+                ["@treatmentTypeID"] = treatmentTypeID,
+                ["@treatmentDetailedActivityTypeID"] = treatmentDetailedActivityTypeID,
+                ["@isFlattened"] = isFlattened,
+                ["@pruningAcresMetadataAttributeID"] = ToSqlID(request.PruningAcresMetadataAttributeID),
+                ["@thinningAcresMetadataAttributeID"] = ToSqlID(request.ThinningAcresMetadataAttributeID),
+                ["@chippingAcresMetadataAttributeID"] = ToSqlID(request.ChippingAcresMetadataAttributeID),
+                ["@masticationAcresMetadataAttributeID"] = ToSqlID(request.MasticationAcresMetadataAttributeID),
+                ["@grazingAcresMetadataAttributeID"] = ToSqlID(request.GrazingAcresMetadataAttributeID),
+                ["@lopScatterAcresMetadataAttributeID"] = ToSqlID(request.LopScatAcresMetadataAttributeID),
+                ["@biomassRemovalAcresMetadataAttributeID"] = ToSqlID(request.BiomassRemovalAcresMetadataAttributeID),
+                ["@handPileAcresMetadataAttributeID"] = ToSqlID(request.HandPileAcresMetadataAttributeID),
+                ["@handPileBurnAcresMetadataAttributeID"] = ToSqlID(request.HandPileBurnAcresMetadataAttributeID),
+                ["@machineBurnAcresMetadataAttributeID"] = ToSqlID(request.MachinePileBurnAcresMetadataAttributeID),
+                ["@broadcastBurnAcresMetadataAttributeID"] = ToSqlID(request.BroadcastBurnAcresMetadataAttributeID),
+                ["@otherBurnAcresMetadataAttributeID"] = ToSqlID(request.OtherAcresMetadataAttributeID),
+                ["@startDateMetadataAttributeID"] = ToSqlID(request.StartDateMetadataAttributeID),
+                ["@endDateMetadataAttributeID"] = ToSqlID(request.CompletionDateMetadataAttributeID),
+            });
         }
         catch (Exception ex)
         {
-            result.Warnings.Add($"Treatment import stored procedure encountered an error: {ex.Message}");
+            // Treatments failed but the projects/locations created above are already committed, so this
+            // stays a warning on an otherwise successful import rather than failing the whole request.
+            // GisBulkImportController logs the populated Warnings so the failure reaches Datadog with
+            // the attempt ID attached — the bare EF "Failed executing DbCommand" entry has no context.
+            result.Warnings.Add(
+                $"Treatment import failed, so no treatments were created for this upload. " +
+                $"Projects and locations were still imported. Error: {ex.Message}");
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Runs the treatment import proc directly against the underlying connection instead of going
+    /// through ExecuteSqlInterpolatedAsync.
+    ///
+    /// EF is configured with EnableRetryOnFailure(maxRetryCount: 3) (WADNR.API/Startup.cs), and SQL
+    /// timeouts are classed transient, so a long-running proc was executed up to four times — burning
+    /// 4 x CommandTimeout before the caller saw a failure, which is what pushed the request past the
+    /// api ingress request-timeout and produced a 504 in the browser. Using the raw connection skips
+    /// the execution strategy, so a timeout fails once, immediately, and visibly.
+    ///
+    /// Retrying is not merely slow here: the proc deletes from dbo.Treatment and dbo.ProjectLocation
+    /// and then re-inserts across many statements, so re-running it over a partially imported state is
+    /// not safe.
+    ///
+    /// NOTE: the proc opens no transaction of its own, so a timeout mid-proc can still leave treatments
+    /// partially imported. Making it atomic is a separate change — see the PR description.
+    /// </summary>
+    private static async Task ExecuteTreatmentImportProcAsync(
+        WADNRDbContext dbContext,
+        Dictionary<string, int> parameters)
+    {
+        var connection = dbContext.Database.GetDbConnection();
+        var openedByThisMethod = connection.State != ConnectionState.Open;
+        if (openedByThisMethod)
+        {
+            await connection.OpenAsync();
+        }
+
+        try
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = "dbo.procImportTreatmentsFromGisUploadAttempt";
+            command.CommandType = CommandType.StoredProcedure;
+            command.CommandTimeout = TreatmentImportCommandTimeoutSeconds;
+
+            foreach (var (parameterName, parameterValue) in parameters)
+            {
+                var parameter = command.CreateParameter();
+                parameter.ParameterName = parameterName;
+                parameter.DbType = DbType.Int32;
+                parameter.Value = parameterValue;
+                command.Parameters.Add(parameter);
+            }
+
+            await command.ExecuteNonQueryAsync();
+        }
+        finally
+        {
+            if (openedByThisMethod)
+            {
+                await connection.CloseAsync();
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to #487. That PR raised the api ingress `request-timeout` to 1200s so the GIS Bulk Import stops returning a 504. This one fixes why the import was taking that long, and why it was failing silently.

## What was happening

`procImportTreatmentsFromGisUploadAttempt` was called via `ExecuteSqlInterpolatedAsync`, which runs under EF's execution strategy. `WADNR.API/Startup.cs:136-138` configures a 180s `CommandTimeout` and `EnableRetryOnFailure(maxRetryCount: 3)`, and SQL timeouts are classed transient — so a long-running import was executed **up to four times, burning 4 × 180s** before the caller saw a failure. That is what pushed the request past the ingress timeout.

Datadog shows 51 of these `CommandTimeout='180'` failures in the last 7 days, across both QA and prod.

Retrying is not merely slow here. The proc deletes from `dbo.Treatment` and `dbo.ProjectLocation` (lines 66/68) and then re-inserts across 14 separate statements, so re-running it over a partially imported state is not safe.

## Changes

**1. Run the proc off the raw connection** — `GisBulkImport.StaticHelpers.cs`

New private `ExecuteTreatmentImportProcAsync` uses `dbContext.Database.GetDbConnection()` directly, which bypasses the execution strategy entirely. A timeout now fails once, immediately, and visibly. It also lets this single command carry its own 600s timeout without touching the global default.

Parameters are bound explicitly as `DbType.Int32` via `CommandType.StoredProcedure` rather than interpolated into an `EXEC` string. Same values, same `-1` sentinel for unmapped attributes.

The method opens the connection only if it is not already open, and closes it only in that case, so EF's connection lifetime is unchanged.

**2. Timeout of 600s** — a judgment call. The old 180s was demonstrably too short; 600s leaves real headroom while staying well under the 1200s ingress ceiling from #487 even after the pre-proc feature loading. Existing precedent in the repo is `SetCommandTimeout(400)` in `LoaUpload.StaticHelpers.cs:135` and `ServiceForestryUpload.StaticHelpers.cs:136`. Happy to change the number if you have a better sense of how long a large import genuinely needs.

**3. Log warnings from the controller** — `GisBulkImportController.cs`

A partially successful import returns 200 with warnings, so the treatment failure was visible to the user (`validate-metadata-step.component.ts:258` renders them) but invisible in Datadog — the only trace was a bare EF `Failed executing DbCommand` entry with no attempt ID on it. The controller now logs populated warnings with the `GisUploadAttemptID`.

The warning text also now states plainly that no treatments were created and that projects and locations still imported, instead of `"Treatment import stored procedure encountered an error: ..."`.

## Deliberately not in this PR

**The proc is not transactional.** It has no `BEGIN TRANSACTION` and no `SET XACT_ABORT`, and each of its ~20 mutations autocommits. A timeout mid-proc leaves treatments deleted and only partially reinserted. This PR makes that far less likely (one attempt instead of four, with a realistic timeout) but does not make the proc atomic.

Fixing it properly means wrapping the proc in a transaction, which trades a partial-import risk for holding locks on `dbo.Treatment` and `dbo.ProjectLocation` for the duration of a large import. That has real production implications and felt like your call rather than something to slip into this PR.

**Hangfire.** Moving the import off the request path remains the durable fix.

## Testing

`dotnet build WADNR.API/WADNR.API.csproj` succeeds with 0 errors (warnings are pre-existing `Magick.NET` / `Microsoft.OpenApi` NuGet advisories).

The test suite could not be run locally: `WADNR.API.Tests` requires `environment.json`, which is gitignored (`.gitignore:69`), and its absence aborts all 691 tests at assembly initialization before any execute. This is a pre-existing local setup gap, unrelated to these changes — worth a look from someone with the file, since the proc call path has no coverage either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)