### PR TITLE
WADNR-2285 Make the GIS bulk import set-based (4.24x, 99% fewer round trips)

### DIFF
--- a/WADNR.API.Tests/GisBulkImportArcGisIdTests.cs
+++ b/WADNR.API.Tests/GisBulkImportArcGisIdTests.cs
@@ -1,7 +1,10 @@
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
+using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.IO.Converters;
 using WADNR.API.Services;
+using WADNR.API.Tests.Helpers;
 using WADNR.EFModels.Entities;
 using WADNR.Models.DataTransferObjects.GisBulkImport;
 
@@ -11,121 +14,57 @@ namespace WADNR.API.Tests;
 /// Covers WADNR-2150 rework: the LOA / Service Forestry import must carry the source Esri
 /// OBJECTID / GlobalID through onto each created ProjectLocation (ArcGisObjectID / ArcGisGlobalID),
 /// which the GDB download's ProjectLocations layer then surfaces. Previously these columns were
-/// never set and came out blank for every LOA record.
+/// never set and came out blank for every LOA record. Also covers WADNR-2272: imported projects must
+/// get County / DNR Upland Region / Priority Landscape populated from their location geometry.
+///
+/// These run against a real SQL Server database. They used to use the InMemory provider, which was
+/// never faithful here and became untenable when region assignment moved to set-based SQL:
+///
+///   - InMemory has no relational provider, so <c>ExecuteSqlRaw</c> throws. Region assignment is now
+///     raw SQL, and the treatment import proc already needed a real connection — that failure was
+///     simply swallowed by the catch that turns proc errors into warnings, so every one of these tests
+///     had been passing with the treatment import silently skipped.
+///   - InMemory evaluates <c>Intersects</c> with in-process NetTopologySuite, which is not the engine
+///     SQL Server uses. A spatial assertion that passes there proves nothing about production.
+///
+/// The two region tests are correspondingly stronger now: instead of seeding a fake county that
+/// trivially overlaps, they compare what the import assigned against what a direct spatial query says
+/// should have been assigned, using the real WA boundary data.
 /// </summary>
 [TestClass]
 public class GisBulkImportArcGisIdTests
 {
-    private const int ProgramID = 5;
-    private const int SourceOrgID = 10;
-    private const int AttemptID = 100;
+    private const string Identifier = "PROJ-1";
 
-    // Metadata attribute IDs seeded per test.
-    private const int IdentifierAttrID = 1;
-    private const int NameAttrID = 2;
-    private const int ObjectIdAttrID = 3;
-    private const int GlobalIdAttrID = 4;
+    private int _programID;
+    private int _sourceOrganizationID;
+    private int _attemptID;
 
-    private static WADNRDbContext NewInMemoryContext()
+    [TestCleanup]
+    public async Task TearDown()
     {
-        var options = new DbContextOptionsBuilder<WADNRDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            // ImportProjectsAsync opens a transaction; the in-memory provider ignores transactions
-            // and would otherwise raise TransactionIgnoredWarning. Ignore it so the create path runs.
-            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
-            .Options;
-        return new WADNRDbContext(options);
-    }
-
-    private static Geometry MakeSquare()
-    {
-        var factory = new GeometryFactory(new PrecisionModel(), 4326);
-        var ring = factory.CreateLinearRing(new[]
+        if (_attemptID == 0)
         {
-            new Coordinate(-120.0, 47.0),
-            new Coordinate(-120.0, 47.1),
-            new Coordinate(-119.9, 47.1),
-            new Coordinate(-119.9, 47.0),
-            new Coordinate(-120.0, 47.0),
-        });
-        return factory.CreatePolygon(ring);
-    }
-
-    /// <summary>
-    /// Seeds the minimum graph for a single new-project create: a source org, an upload attempt,
-    /// one ProjectType, and one GisFeature whose metadata always carries an identifier + name and
-    /// optionally an objectid / globalid.
-    /// </summary>
-    private static async Task SeedAsync(WADNRDbContext db, string? objectIdValue, string? globalIdValue)
-    {
-        db.ProjectTypes.Add(new ProjectType { ProjectTypeID = 1, ProjectTypeName = "Default" });
-
-        db.GisUploadSourceOrganizations.Add(new GisUploadSourceOrganization
-        {
-            GisUploadSourceOrganizationID = SourceOrgID,
-            GisUploadSourceOrganizationName = "LOA Test Source",
-            ProgramID = ProgramID,
-            ProjectStageDefaultID = (int)ProjectStageEnum.Implementation,
-            ProjectTypeDefaultName = "Default",
-            DefaultLeadImplementerOrganizationID = 1,
-            RelationshipTypeForDefaultOrganizationID = 1,
-            ApplyStartDateToProject = false,
-            ApplyCompletedDateToProject = false,
-        });
-
-        db.GisUploadAttempts.Add(new GisUploadAttempt
-        {
-            GisUploadAttemptID = AttemptID,
-            GisUploadSourceOrganizationID = SourceOrgID,
-            GisUploadAttemptCreatePersonID = 1,
-            GisUploadAttemptCreateDate = new DateTime(2026, 6, 16, 0, 0, 0, DateTimeKind.Utc),
-        });
-
-        db.GisMetadataAttributes.Add(new GisMetadataAttribute { GisMetadataAttributeID = IdentifierAttrID, GisMetadataAttributeName = "approval_id" });
-        db.GisMetadataAttributes.Add(new GisMetadataAttribute { GisMetadataAttributeID = NameAttrID, GisMetadataAttributeName = "project_name" });
-        db.GisMetadataAttributes.Add(new GisMetadataAttribute { GisMetadataAttributeID = ObjectIdAttrID, GisMetadataAttributeName = "objectid" });
-        db.GisMetadataAttributes.Add(new GisMetadataAttribute { GisMetadataAttributeID = GlobalIdAttrID, GisMetadataAttributeName = "globalid" });
-
-        db.GisFeatures.Add(new GisFeature
-        {
-            GisFeatureID = 1000,
-            GisUploadAttemptID = AttemptID,
-            GisFeatureGeometry = MakeSquare(),
-            GisImportFeatureKey = 0,
-            IsValid = true,
-        });
-
-        var metaID = 1;
-        db.GisFeatureMetadataAttributes.Add(new GisFeatureMetadataAttribute { GisFeatureMetadataAttributeID = metaID++, GisFeatureID = 1000, GisMetadataAttributeID = IdentifierAttrID, GisFeatureMetadataAttributeValue = "PROJ-1" });
-        db.GisFeatureMetadataAttributes.Add(new GisFeatureMetadataAttribute { GisFeatureMetadataAttributeID = metaID++, GisFeatureID = 1000, GisMetadataAttributeID = NameAttrID, GisFeatureMetadataAttributeValue = "Test LOA Project" });
-        if (objectIdValue != null)
-        {
-            db.GisFeatureMetadataAttributes.Add(new GisFeatureMetadataAttribute { GisFeatureMetadataAttributeID = metaID++, GisFeatureID = 1000, GisMetadataAttributeID = ObjectIdAttrID, GisFeatureMetadataAttributeValue = objectIdValue });
-        }
-        if (globalIdValue != null)
-        {
-            db.GisFeatureMetadataAttributes.Add(new GisFeatureMetadataAttribute { GisFeatureMetadataAttributeID = metaID++, GisFeatureID = 1000, GisMetadataAttributeID = GlobalIdAttrID, GisFeatureMetadataAttributeValue = globalIdValue });
+            return;
         }
 
-        await db.SaveChangesWithNoAuditingAsync();
+        await using var dbContext = NewContext();
+        await TearDownFixtureAsync(dbContext);
+        _attemptID = 0;
     }
 
-    private static GisBulkImportRequest BuildRequest() => new()
-    {
-        ProjectIdentifierMetadataAttributeID = IdentifierAttrID,
-        ProjectNameMetadataAttributeID = NameAttrID,
-    };
+    #region ArcGIS identifier carry-through
 
     [TestMethod]
     public async Task ImportProjects_SetsArcGisObjectIDAndGlobalID_WhenMetadataPresent()
     {
-        await using var db = NewInMemoryContext();
-        await SeedAsync(db, objectIdValue: "4242", globalIdValue: "{ABC-123}");
+        await using var db = NewContext();
+        var request = await ArrangeAsync(db, objectIdValue: "4242", globalIdValue: "{ABC-123}");
 
-        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+        var result = await GisBulkImports.ImportProjectsAsync(db, _attemptID, request);
 
         Assert.AreEqual(1, result.ProjectsCreated);
-        var location = await db.ProjectLocations.SingleAsync();
+        var location = await SingleImportedLocationAsync(db);
         Assert.AreEqual(4242, location.ArcGisObjectID);
         Assert.AreEqual("{ABC-123}", location.ArcGisGlobalID);
     }
@@ -133,13 +72,13 @@ public class GisBulkImportArcGisIdTests
     [TestMethod]
     public async Task ImportProjects_LeavesArcGisColumnsNull_WhenMetadataAbsent()
     {
-        await using var db = NewInMemoryContext();
-        await SeedAsync(db, objectIdValue: null, globalIdValue: null);
+        await using var db = NewContext();
+        var request = await ArrangeAsync(db, objectIdValue: null, globalIdValue: null);
 
-        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+        var result = await GisBulkImports.ImportProjectsAsync(db, _attemptID, request);
 
         Assert.AreEqual(1, result.ProjectsCreated);
-        var location = await db.ProjectLocations.SingleAsync();
+        var location = await SingleImportedLocationAsync(db);
         Assert.IsNull(location.ArcGisObjectID);
         Assert.IsNull(location.ArcGisGlobalID);
     }
@@ -147,16 +86,20 @@ public class GisBulkImportArcGisIdTests
     [TestMethod]
     public async Task ImportProjects_DoesNotThrowAndLeavesObjectIDNull_WhenObjectIdUnparseable()
     {
-        await using var db = NewInMemoryContext();
-        await SeedAsync(db, objectIdValue: "not-a-number", globalIdValue: "{XYZ}");
+        await using var db = NewContext();
+        var request = await ArrangeAsync(db, objectIdValue: "not-a-number", globalIdValue: "{XYZ}");
 
-        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+        var result = await GisBulkImports.ImportProjectsAsync(db, _attemptID, request);
 
         Assert.AreEqual(1, result.ProjectsCreated);
-        var location = await db.ProjectLocations.SingleAsync();
+        var location = await SingleImportedLocationAsync(db);
         Assert.IsNull(location.ArcGisObjectID);
         Assert.AreEqual("{XYZ}", location.ArcGisGlobalID);
     }
+
+    #endregion
+
+    #region Location naming (WADNR-2150)
 
     [TestMethod]
     public async Task ImportProjects_NamesLocationFromObjectID_WhenObjectIdPresent()
@@ -164,84 +107,98 @@ public class GisBulkImportArcGisIdTests
         // The location name must derive from the stable Esri OBJECTID, not the positional
         // GisImportFeatureKey, so re-imports produce identical names and cross-feature/cross-program
         // name collisions on AK_ProjectLocation_ProjectID_ProgramID_ProjectLocationName are avoided.
-        await using var db = NewInMemoryContext();
-        await SeedAsync(db, objectIdValue: "4242", globalIdValue: "{ABC-123}");
+        await using var db = NewContext();
+        var request = await ArrangeAsync(db, objectIdValue: "4242", globalIdValue: "{ABC-123}");
 
-        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+        await GisBulkImports.ImportProjectsAsync(db, _attemptID, request);
 
-        var location = await db.ProjectLocations.SingleAsync();
-        Assert.AreEqual("PROJ-1 - Feature 4242", location.ProjectLocationName);
+        var location = await SingleImportedLocationAsync(db);
+        Assert.AreEqual($"{Identifier} - Feature 4242", location.ProjectLocationName);
     }
 
     [TestMethod]
     public async Task ImportProjects_NamesLocationFromGlobalID_WhenObjectIdAbsent()
     {
-        await using var db = NewInMemoryContext();
-        await SeedAsync(db, objectIdValue: null, globalIdValue: "{ABC-123}");
+        await using var db = NewContext();
+        var request = await ArrangeAsync(db, objectIdValue: null, globalIdValue: "{ABC-123}");
 
-        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+        await GisBulkImports.ImportProjectsAsync(db, _attemptID, request);
 
-        var location = await db.ProjectLocations.SingleAsync();
-        Assert.AreEqual("PROJ-1 - Feature {ABC-123}", location.ProjectLocationName);
+        var location = await SingleImportedLocationAsync(db);
+        Assert.AreEqual($"{Identifier} - Feature {{ABC-123}}", location.ProjectLocationName);
     }
 
     [TestMethod]
     public async Task ImportProjects_NamesLocationFromFeatureKey_WhenNoEsriIdentifiers()
     {
         // Non-Esri sources carry neither OBJECTID nor GlobalID; fall back to the feature key.
-        await using var db = NewInMemoryContext();
-        await SeedAsync(db, objectIdValue: null, globalIdValue: null);
+        await using var db = NewContext();
+        var request = await ArrangeAsync(db, objectIdValue: null, globalIdValue: null);
 
-        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+        await GisBulkImports.ImportProjectsAsync(db, _attemptID, request);
 
-        var location = await db.ProjectLocations.SingleAsync();
-        Assert.AreEqual("PROJ-1 - Feature 0", location.ProjectLocationName);
+        var location = await SingleImportedLocationAsync(db);
+        Assert.AreEqual($"{Identifier} - Feature 0", location.ProjectLocationName);
     }
+
+    #endregion
+
+    #region Geographic region assignment (WADNR-2272)
 
     [TestMethod]
     public async Task ImportProjects_AssignsCountyRegionAndPriorityLandscape_FromLocationGeometry()
     {
-        // WADNR-2272: imported projects were not getting location-based data set. The import must
-        // populate County / DNR Upland Region / Priority Landscape from the created location
-        // geometry, mirroring the interactive project workflow (AutoAssignGeographicRegionsAsync).
-        await using var db = NewInMemoryContext();
-        await SeedAsync(db, objectIdValue: "4242", globalIdValue: "{ABC-123}");
+        // WADNR-2272: imported projects were not getting location-based data set. Asserted against
+        // ground truth computed by an independent spatial query over the real boundary tables, rather
+        // than against a seeded polygon that trivially overlaps — so this now verifies the import agrees
+        // with SQL Server's spatial engine on real Washington data.
+        await using var db = NewContext();
+        var request = await ArrangeAsync(db, objectIdValue: "4242", globalIdValue: "{ABC-123}", geometry: InsideWashington());
 
-        // A county, region, and priority landscape whose boundary overlaps the feature square.
-        var overlapping = MakeSquare();
-        db.Counties.Add(new County { CountyID = 1, CountyName = "Test County", StateProvinceID = 1, CountyFeature = overlapping });
-        db.DNRUplandRegions.Add(new DNRUplandRegion { DNRUplandRegionID = 1, DNRUplandRegionName = "Test Region", DNRUplandRegionLocation = overlapping });
-        db.PriorityLandscapes.Add(new PriorityLandscape { PriorityLandscapeID = 1, PriorityLandscapeName = "Test Priority Landscape", PriorityLandscapeLocation = overlapping });
-        await db.SaveChangesWithNoAuditingAsync();
-
-        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+        var result = await GisBulkImports.ImportProjectsAsync(db, _attemptID, request);
 
         Assert.AreEqual(1, result.ProjectsCreated);
-        var projectID = (await db.Projects.SingleAsync()).ProjectID;
-        Assert.AreEqual(1, await db.ProjectCounties.CountAsync(x => x.ProjectID == projectID), "Expected the intersecting county to be assigned.");
-        Assert.AreEqual(1, await db.ProjectRegions.CountAsync(x => x.ProjectID == projectID), "Expected the intersecting DNR upland region to be assigned.");
-        Assert.AreEqual(1, await db.ProjectPriorityLandscapes.CountAsync(x => x.ProjectID == projectID), "Expected the intersecting priority landscape to be assigned.");
+        var projectID = (await ImportedProjectsAsync(db)).Single();
+
+        var expected = await ExpectedRegionsAsync(db, InsideWashington());
+        Assert.IsTrue(expected.Counties > 0,
+            "Fixture geometry no longer intersects any County, so this test would pass vacuously.");
+
+        Assert.AreEqual(expected.Counties, await db.ProjectCounties.CountAsync(x => x.ProjectID == projectID),
+            "Assigned counties should match what a direct spatial query returns.");
+        Assert.AreEqual(expected.Regions, await db.ProjectRegions.CountAsync(x => x.ProjectID == projectID),
+            "Assigned DNR upland regions should match what a direct spatial query returns.");
+        Assert.AreEqual(expected.PriorityLandscapes, await db.ProjectPriorityLandscapes.CountAsync(x => x.ProjectID == projectID),
+            "Assigned priority landscapes should match what a direct spatial query returns.");
     }
 
     [TestMethod]
     public async Task ImportProjects_LeavesLocationDataEmptyAndSetsExplanations_WhenNoBoundaryIntersects()
     {
-        // No county / region / priority landscape seeded, so nothing intersects: the import must
-        // still succeed, leave the join tables empty, and record the "does not intersect" explanations.
-        await using var db = NewInMemoryContext();
-        await SeedAsync(db, objectIdValue: "4242", globalIdValue: "{ABC-123}");
+        // Geometry far outside Washington, so nothing intersects: the import must still succeed, leave
+        // the join tables empty, and record the "does not intersect" explanations.
+        await using var db = NewContext();
+        var request = await ArrangeAsync(db, objectIdValue: "4242", globalIdValue: "{ABC-123}", geometry: FarFromWashington());
 
-        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+        var result = await GisBulkImports.ImportProjectsAsync(db, _attemptID, request);
 
         Assert.AreEqual(1, result.ProjectsCreated);
-        var project = await db.Projects.SingleAsync();
-        Assert.AreEqual(0, await db.ProjectCounties.CountAsync(x => x.ProjectID == project.ProjectID));
-        Assert.AreEqual(0, await db.ProjectRegions.CountAsync(x => x.ProjectID == project.ProjectID));
-        Assert.AreEqual(0, await db.ProjectPriorityLandscapes.CountAsync(x => x.ProjectID == project.ProjectID));
+        var projectID = (await ImportedProjectsAsync(db)).Single();
+
+        Assert.AreEqual(0, await db.ProjectCounties.CountAsync(x => x.ProjectID == projectID));
+        Assert.AreEqual(0, await db.ProjectRegions.CountAsync(x => x.ProjectID == projectID));
+        Assert.AreEqual(0, await db.ProjectPriorityLandscapes.CountAsync(x => x.ProjectID == projectID));
+
+        db.ChangeTracker.Clear();
+        var project = await db.Projects.AsNoTracking().SingleAsync(p => p.ProjectID == projectID);
         Assert.IsNotNull(project.NoCountiesExplanation);
         Assert.IsNotNull(project.NoRegionsExplanation);
         Assert.IsNotNull(project.NoPriorityLandscapesExplanation);
     }
+
+    #endregion
+
+    #region BuildOutFields (no database)
 
     [TestMethod]
     public void BuildOutFields_AppendsObjectIdAndGlobalId_WhenIncludeGlobalIdTrue()
@@ -277,4 +234,197 @@ public class GisBulkImportArcGisIdTests
         Assert.AreEqual(1, fields.Count(f => string.Equals(f, "objectid", StringComparison.OrdinalIgnoreCase)));
         Assert.AreEqual(1, fields.Count(f => string.Equals(f, "globalid", StringComparison.OrdinalIgnoreCase)));
     }
+
+    #endregion
+
+    #region Fixture
+
+    private static WADNRDbContext NewContext()
+    {
+        var connectionString = AssemblySteps.Configuration["sqlConnectionString"]
+            ?? throw new InvalidOperationException("sqlConnectionString not found in environment.json");
+
+        var options = new DbContextOptionsBuilder<WADNRDbContext>()
+            .UseSqlServer(connectionString, x =>
+            {
+                x.UseNetTopologySuite();
+                x.EnableRetryOnFailure(maxRetryCount: 3, maxRetryDelay: TimeSpan.FromSeconds(5), errorNumbersToAdd: null);
+            })
+            .Options;
+
+        return new WADNRDbContext(options, AssemblySteps.AuditUserProvider);
+    }
+
+    /// <summary>Eastern Washington, so it intersects real County / DNRUplandRegion geometry.</summary>
+    private static Geometry InsideWashington() => Square(-120.0, 47.0);
+
+    /// <summary>Mid-Atlantic, so nothing in the WA boundary tables can intersect it.</summary>
+    private static Geometry FarFromWashington() => Square(-40.0, 30.0);
+
+    private static Geometry Square(double minX, double minY)
+    {
+        const double size = 0.1;
+        var factory = new GeometryFactory(new PrecisionModel(), 4326);
+        return factory.CreatePolygon(factory.CreateLinearRing(
+        [
+            new Coordinate(minX, minY),
+            new Coordinate(minX, minY + size),
+            new Coordinate(minX + size, minY + size),
+            new Coordinate(minX + size, minY),
+            new Coordinate(minX, minY)
+        ]));
+    }
+
+    /// <summary>
+    /// Seeds Program + source org + attempt, stages one feature through the real upload path, and
+    /// returns the import request.
+    ///
+    /// Staging via <c>UploadAndProcessFileAsync</c> rather than hand-inserting GisFeature rows is what
+    /// creates the GisMetadataAttribute and GisUploadAttemptGisMetadataAttribute records the import
+    /// joins through, and it keeps the fixture honest about what production actually produces.
+    /// </summary>
+    private async Task<GisBulkImportRequest> ArrangeAsync(
+        WADNRDbContext dbContext, string? objectIdValue, string? globalIdValue, Geometry? geometry = null)
+    {
+        var program = await ProgramHelper.CreateProgramAsync(
+            dbContext, AssemblySteps.TestAdminPersonID, name: $"ArcGis Id Test {DateTime.UtcNow:yyyyMMddHHmmssfff}");
+        _programID = program.ProgramID;
+
+        var organizationID = (await dbContext.Organizations.AsNoTracking().OrderBy(x => x.OrganizationID).FirstAsync()).OrganizationID;
+        var relationshipTypeID = (await dbContext.RelationshipTypes.AsNoTracking().OrderBy(x => x.RelationshipTypeID).FirstAsync()).RelationshipTypeID;
+        var projectTypeName = (await dbContext.ProjectTypes.AsNoTracking().OrderBy(x => x.ProjectTypeID).FirstAsync()).ProjectTypeName;
+
+        var sourceOrganization = new GisUploadSourceOrganization
+        {
+            GisUploadSourceOrganizationName = $"ArcGis Id Test Source {program.ProgramID}",
+            ProgramID = program.ProgramID,
+            ProjectStageDefaultID = (int)ProjectStageEnum.Implementation,
+            ProjectTypeDefaultName = projectTypeName,
+            DefaultLeadImplementerOrganizationID = organizationID,
+            RelationshipTypeForDefaultOrganizationID = relationshipTypeID,
+            ApplyStartDateToProject = false,
+            ApplyCompletedDateToProject = false,
+            ImportIsFlattened = false
+        };
+        dbContext.GisUploadSourceOrganizations.Add(sourceOrganization);
+        await dbContext.SaveChangesWithNoAuditingAsync();
+        _sourceOrganizationID = sourceOrganization.GisUploadSourceOrganizationID;
+
+        var attempt = new GisUploadAttempt
+        {
+            GisUploadSourceOrganizationID = sourceOrganization.GisUploadSourceOrganizationID,
+            GisUploadAttemptCreatePersonID = AssemblySteps.TestAdminPersonID,
+            GisUploadAttemptCreateDate = new DateTime(2026, 6, 16, 0, 0, 0, DateTimeKind.Utc)
+        };
+        dbContext.GisUploadAttempts.Add(attempt);
+        await dbContext.SaveChangesWithNoAuditingAsync();
+        _attemptID = attempt.GisUploadAttemptID;
+
+        await GisBulkImports.UploadAndProcessFileAsync(
+            dbContext, _attemptID, BuildGeoJson(objectIdValue, globalIdValue, geometry ?? InsideWashington()));
+
+        var attributeIDByName = await dbContext.GisUploadAttemptGisMetadataAttributes
+            .AsNoTracking()
+            .Where(x => x.GisUploadAttemptID == _attemptID)
+            .Select(x => new { x.GisMetadataAttributeID, x.GisMetadataAttribute.GisMetadataAttributeName })
+            .ToDictionaryAsync(x => x.GisMetadataAttributeName, x => x.GisMetadataAttributeID, StringComparer.OrdinalIgnoreCase);
+
+        return new GisBulkImportRequest
+        {
+            ProjectIdentifierMetadataAttributeID = attributeIDByName["approval_id"],
+            ProjectNameMetadataAttributeID = attributeIDByName["project_name"]
+        };
+    }
+
+    private static string BuildGeoJson(string? objectIdValue, string? globalIdValue, Geometry geometry)
+    {
+        var attributes = new AttributesTable
+        {
+            { "approval_id", Identifier },
+            { "project_name", "Test LOA Project" }
+        };
+        if (objectIdValue != null)
+        {
+            attributes.Add("objectid", objectIdValue);
+        }
+        if (globalIdValue != null)
+        {
+            attributes.Add("globalid", globalIdValue);
+        }
+
+        var featureCollection = new FeatureCollection { new Feature(geometry, attributes) };
+
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new GeoJsonConverterFactory());
+        return JsonSerializer.Serialize(featureCollection, options);
+    }
+
+    /// <summary>What a direct spatial query says should intersect, independent of the import.</summary>
+    private static async Task<(int Counties, int Regions, int PriorityLandscapes)> ExpectedRegionsAsync(
+        WADNRDbContext dbContext, Geometry geometry) =>
+    (
+        await dbContext.Counties.AsNoTracking().CountAsync(c => c.CountyFeature.Intersects(geometry)),
+        await dbContext.DNRUplandRegions.AsNoTracking().CountAsync(r => r.DNRUplandRegionLocation.Intersects(geometry)),
+        await dbContext.PriorityLandscapes.AsNoTracking().CountAsync(p => p.PriorityLandscapeLocation.Intersects(geometry))
+    );
+
+    private async Task<List<int>> ImportedProjectsAsync(WADNRDbContext dbContext) =>
+        await dbContext.Projects
+            .AsNoTracking()
+            .Where(p => p.CreateGisUploadAttemptID == _attemptID || p.LastUpdateGisUploadAttemptID == _attemptID)
+            .Select(p => p.ProjectID)
+            .ToListAsync();
+
+    /// <summary>
+    /// The single location the import created. Filtered on ImportedFromGisUpload because
+    /// procImportTreatmentsFromGisUploadAttempt creates its own ProjectLocation rows, which now really
+    /// run — under the InMemory provider they never did.
+    /// </summary>
+    private async Task<ProjectLocation> SingleImportedLocationAsync(WADNRDbContext dbContext)
+    {
+        var projectIDs = await ImportedProjectsAsync(dbContext);
+        return await dbContext.ProjectLocations
+            .AsNoTracking()
+            .SingleAsync(l => projectIDs.Contains(l.ProjectID) && l.ImportedFromGisUpload == true);
+    }
+
+    private async Task TearDownFixtureAsync(WADNRDbContext dbContext)
+    {
+        dbContext.ChangeTracker.Clear();
+
+        var projectIDs = await ImportedProjectsAsync(dbContext);
+        if (projectIDs.Count > 0)
+        {
+            await dbContext.Treatments.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectLocations.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectCounties.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectRegions.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectPriorityLandscapes.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectPrograms.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectOrganizations.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.Projects.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+        }
+
+        var featureIDs = dbContext.GisFeatures.Where(f => f.GisUploadAttemptID == _attemptID).Select(f => f.GisFeatureID);
+        await dbContext.GisFeatureMetadataAttributes.Where(x => featureIDs.Contains(x.GisFeatureID)).ExecuteDeleteAsync();
+        await dbContext.GisFeatures.Where(x => x.GisUploadAttemptID == _attemptID).ExecuteDeleteAsync();
+        await dbContext.GisUploadAttemptGisMetadataAttributes.Where(x => x.GisUploadAttemptID == _attemptID).ExecuteDeleteAsync();
+        await dbContext.GisUploadAttempts.Where(x => x.GisUploadAttemptID == _attemptID).ExecuteDeleteAsync();
+
+        if (_sourceOrganizationID != 0)
+        {
+            await dbContext.GisUploadSourceOrganizations
+                .Where(x => x.GisUploadSourceOrganizationID == _sourceOrganizationID).ExecuteDeleteAsync();
+        }
+
+        if (_programID != 0)
+        {
+            await dbContext.Programs.Where(x => x.ProgramID == _programID).ExecuteDeleteAsync();
+        }
+
+        // GisMetadataAttribute rows are shared global data the production code only ever adds to.
+        dbContext.ChangeTracker.Clear();
+    }
+
+    #endregion
 }

--- a/WADNR.API.Tests/GisBulkImportArcGisIdTests.cs
+++ b/WADNR.API.Tests/GisBulkImportArcGisIdTests.cs
@@ -196,6 +196,99 @@ public class GisBulkImportArcGisIdTests
         Assert.IsNotNull(project.NoPriorityLandscapesExplanation);
     }
 
+    [TestMethod]
+    public async Task ImportProjects_AssignsEachProjectItsOwnRegions_WhenImportingSeveralAtOnce()
+    {
+        // Region assignment is one set-based SQL batch over every project in the import: temp tables,
+        // an OPENJSON project list, and a CROSS JOIN against the boundary tables reduced with
+        // DISTINCT g.ProjectID. If that per-project scoping were wrong — a join dropped, the DISTINCT
+        // widened — every project in the batch would receive the union of all their regions, and a
+        // single-project fixture could never tell. So: two projects at opposite ends of the state,
+        // asserted by ID against what an independent spatial query returns for each one's own
+        // geometry.
+        await using var db = NewContext();
+        var eastern = EasternWashington();
+        var northwestern = NorthwesternWashington();
+        var request = await ArrangeMultiAsync(db, ("PROJ-EAST", eastern), ("PROJ-NW", northwestern));
+
+        var expectedEasternCounties = await ExpectedCountyIDsAsync(db, eastern);
+        var expectedNorthwesternCounties = await ExpectedCountyIDsAsync(db, northwestern);
+
+        // Fixture guards: without these the disjointness assertions below could pass vacuously.
+        Assert.IsTrue(expectedEasternCounties.Count > 0 && expectedNorthwesternCounties.Count > 0,
+            "Both fixture geometries must intersect a County, or this test proves nothing.");
+        Assert.AreEqual(0, expectedEasternCounties.Intersect(expectedNorthwesternCounties).Count(),
+            "The two fixture geometries must sit in different counties for cross-contamination to be detectable.");
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, _attemptID, request);
+
+        Assert.AreEqual(2, result.ProjectsCreated);
+
+        var projectIDByIdentifier = await ProjectIDByGisIdentifierAsync(db);
+
+        CollectionAssert.AreEquivalent(
+            expectedEasternCounties,
+            await AssignedCountyIDsAsync(db, projectIDByIdentifier["PROJ-EAST"]),
+            "The eastern project must get exactly its own counties — not the other project's as well.");
+        CollectionAssert.AreEquivalent(
+            expectedNorthwesternCounties,
+            await AssignedCountyIDsAsync(db, projectIDByIdentifier["PROJ-NW"]),
+            "The northwestern project must get exactly its own counties — not the other project's as well.");
+
+        // Same check one level up: DNR upland regions are assigned by the same batch and the same join.
+        CollectionAssert.AreEquivalent(
+            await ExpectedRegionIDsAsync(db, eastern),
+            await AssignedRegionIDsAsync(db, projectIDByIdentifier["PROJ-EAST"]));
+        CollectionAssert.AreEquivalent(
+            await ExpectedRegionIDsAsync(db, northwestern),
+            await AssignedRegionIDsAsync(db, projectIDByIdentifier["PROJ-NW"]));
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_ReplacesLocationsAndRegions_WhenSeveralProjectsAreReImported()
+    {
+        // The prior-location cleanup is now one SELECT plus two deletes for the whole import rather
+        // than three statements per project, and region assignment likewise deletes and re-inserts in
+        // one batch. Re-importing the same features must therefore leave exactly what the first run
+        // left — no duplicated locations, no stacked region rows — across more than one project.
+        await using var db = NewContext();
+        var eastern = EasternWashington();
+        var northwestern = NorthwesternWashington();
+        var features = new[] { ("PROJ-EAST", eastern), ("PROJ-NW", northwestern) };
+        var request = await ArrangeMultiAsync(db, features);
+
+        var firstRun = await GisBulkImports.ImportProjectsAsync(db, _attemptID, request);
+        Assert.AreEqual(2, firstRun.ProjectsCreated);
+        Assert.AreEqual(2, firstRun.LocationsCreated);
+
+        var projectIDByIdentifier = await ProjectIDByGisIdentifierAsync(db);
+        var easternCountiesAfterFirstRun = await AssignedCountyIDsAsync(db, projectIDByIdentifier["PROJ-EAST"]);
+
+        // A successful import clears its own staged features, so re-stage before running again.
+        db.ChangeTracker.Clear();
+        await StageFeaturesAsync(db, features);
+
+        var secondRun = await GisBulkImports.ImportProjectsAsync(db, _attemptID, request);
+
+        Assert.AreEqual(0, secondRun.ProjectsCreated,
+            "Both projects already exist under this program, so the second run must match rather than duplicate them.");
+        Assert.AreEqual(2, secondRun.ProjectsUpdated);
+
+        db.ChangeTracker.Clear();
+        Assert.AreEqual(2, (await ImportedProjectsAsync(db)).Count,
+            "Re-importing must not create a second project per identifier.");
+
+        var projectIDs = await ImportedProjectsAsync(db);
+        Assert.AreEqual(2, await db.ProjectLocations
+                .CountAsync(l => projectIDs.Contains(l.ProjectID) && l.ImportedFromGisUpload == true),
+            "The batched delete must clear the first run's project areas before the second run re-creates them.");
+
+        CollectionAssert.AreEquivalent(
+            easternCountiesAfterFirstRun,
+            await AssignedCountyIDsAsync(db, projectIDByIdentifier["PROJ-EAST"]),
+            "Region assignment deletes and re-inserts, so a re-import must land on the same set, not a doubled one.");
+    }
+
     #endregion
 
     #region BuildOutFields (no database)
@@ -261,6 +354,15 @@ public class GisBulkImportArcGisIdTests
     /// <summary>Mid-Atlantic, so nothing in the WA boundary tables can intersect it.</summary>
     private static Geometry FarFromWashington() => Square(-40.0, 30.0);
 
+    /// <summary>
+    /// Two squares roughly 300km apart at opposite ends of the state, so they fall in different
+    /// counties and different DNR upland regions. The multi-project tests rely on that separation to
+    /// detect a batch that assigns one project's regions to another.
+    /// </summary>
+    private static Geometry EasternWashington() => Square(-118.5, 46.4);
+
+    private static Geometry NorthwesternWashington() => Square(-122.4, 48.4);
+
     private static Geometry Square(double minX, double minY)
     {
         const double size = 0.1;
@@ -285,6 +387,73 @@ public class GisBulkImportArcGisIdTests
     /// </summary>
     private async Task<GisBulkImportRequest> ArrangeAsync(
         WADNRDbContext dbContext, string? objectIdValue, string? globalIdValue, Geometry? geometry = null)
+    {
+        await SeedFixtureAsync(dbContext);
+
+        await GisBulkImports.UploadAndProcessFileAsync(
+            dbContext, _attemptID, BuildGeoJson(objectIdValue, globalIdValue, geometry ?? InsideWashington()));
+
+        return await BuildRequestAsync(dbContext);
+    }
+
+    /// <summary>
+    /// Stages several features, one per project identifier, through the same real upload path.
+    /// Used by the multi-project tests: the import is set-based, so a single-project fixture leaves
+    /// the batching — and the region SQL's per-project scoping in particular — unexercised.
+    /// </summary>
+    private async Task<GisBulkImportRequest> ArrangeMultiAsync(
+        WADNRDbContext dbContext, params (string Identifier, Geometry Geometry)[] features)
+    {
+        await SeedFixtureAsync(dbContext);
+        await StageFeaturesAsync(dbContext, features);
+        return await BuildRequestAsync(dbContext);
+    }
+
+    /// <summary>One feature per project identifier, each with its own geometry.</summary>
+    private static string BuildMultiFeatureGeoJson((string Identifier, Geometry Geometry)[] features)
+    {
+        var featureCollection = new FeatureCollection();
+        foreach (var (identifier, geometry) in features)
+        {
+            featureCollection.Add(new Feature(geometry, new AttributesTable
+            {
+                { "approval_id", identifier },
+                { "project_name", $"Test Project {identifier}" }
+            }));
+        }
+
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new GeoJsonConverterFactory());
+        return JsonSerializer.Serialize(featureCollection, options);
+    }
+
+    /// <summary>
+    /// Stages the given features onto this attempt. UploadAndProcessFileAsync clears the attempt's
+    /// prior staged rows first, so calling this a second time is exactly what a repeat upload of the
+    /// same GDB does — and it is the only way to exercise a second import, because a successful one
+    /// clears its own staged features.
+    /// </summary>
+    private async Task StageFeaturesAsync(
+        WADNRDbContext dbContext, params (string Identifier, Geometry Geometry)[] features) =>
+        await GisBulkImports.UploadAndProcessFileAsync(
+            dbContext, _attemptID, BuildMultiFeatureGeoJson(features));
+
+    private async Task<GisBulkImportRequest> BuildRequestAsync(WADNRDbContext dbContext)
+    {
+        var attributeIDByName = await dbContext.GisUploadAttemptGisMetadataAttributes
+            .AsNoTracking()
+            .Where(x => x.GisUploadAttemptID == _attemptID)
+            .Select(x => new { x.GisMetadataAttributeID, x.GisMetadataAttribute.GisMetadataAttributeName })
+            .ToDictionaryAsync(x => x.GisMetadataAttributeName, x => x.GisMetadataAttributeID, StringComparer.OrdinalIgnoreCase);
+
+        return new GisBulkImportRequest
+        {
+            ProjectIdentifierMetadataAttributeID = attributeIDByName["approval_id"],
+            ProjectNameMetadataAttributeID = attributeIDByName["project_name"]
+        };
+    }
+
+    private async Task SeedFixtureAsync(WADNRDbContext dbContext)
     {
         var program = await ProgramHelper.CreateProgramAsync(
             dbContext, AssemblySteps.TestAdminPersonID, name: $"ArcGis Id Test {DateTime.UtcNow:yyyyMMddHHmmssfff}");
@@ -319,21 +488,6 @@ public class GisBulkImportArcGisIdTests
         dbContext.GisUploadAttempts.Add(attempt);
         await dbContext.SaveChangesWithNoAuditingAsync();
         _attemptID = attempt.GisUploadAttemptID;
-
-        await GisBulkImports.UploadAndProcessFileAsync(
-            dbContext, _attemptID, BuildGeoJson(objectIdValue, globalIdValue, geometry ?? InsideWashington()));
-
-        var attributeIDByName = await dbContext.GisUploadAttemptGisMetadataAttributes
-            .AsNoTracking()
-            .Where(x => x.GisUploadAttemptID == _attemptID)
-            .Select(x => new { x.GisMetadataAttributeID, x.GisMetadataAttribute.GisMetadataAttributeName })
-            .ToDictionaryAsync(x => x.GisMetadataAttributeName, x => x.GisMetadataAttributeID, StringComparer.OrdinalIgnoreCase);
-
-        return new GisBulkImportRequest
-        {
-            ProjectIdentifierMetadataAttributeID = attributeIDByName["approval_id"],
-            ProjectNameMetadataAttributeID = attributeIDByName["project_name"]
-        };
     }
 
     private static string BuildGeoJson(string? objectIdValue, string? globalIdValue, Geometry geometry)
@@ -367,6 +521,31 @@ public class GisBulkImportArcGisIdTests
         await dbContext.DNRUplandRegions.AsNoTracking().CountAsync(r => r.DNRUplandRegionLocation.Intersects(geometry)),
         await dbContext.PriorityLandscapes.AsNoTracking().CountAsync(p => p.PriorityLandscapeLocation.Intersects(geometry))
     );
+
+    /// <summary>Which County / DNRUplandRegion rows a direct spatial query says a geometry hits.</summary>
+    private static async Task<List<int>> ExpectedCountyIDsAsync(WADNRDbContext dbContext, Geometry geometry) =>
+        await dbContext.Counties.AsNoTracking()
+            .Where(c => c.CountyFeature.Intersects(geometry)).Select(c => c.CountyID).ToListAsync();
+
+    private static async Task<List<int>> ExpectedRegionIDsAsync(WADNRDbContext dbContext, Geometry geometry) =>
+        await dbContext.DNRUplandRegions.AsNoTracking()
+            .Where(r => r.DNRUplandRegionLocation.Intersects(geometry)).Select(r => r.DNRUplandRegionID).ToListAsync();
+
+    /// <summary>What the import actually assigned.</summary>
+    private static async Task<List<int>> AssignedCountyIDsAsync(WADNRDbContext dbContext, int projectID) =>
+        await dbContext.ProjectCounties.AsNoTracking()
+            .Where(x => x.ProjectID == projectID).Select(x => x.CountyID).ToListAsync();
+
+    private static async Task<List<int>> AssignedRegionIDsAsync(WADNRDbContext dbContext, int projectID) =>
+        await dbContext.ProjectRegions.AsNoTracking()
+            .Where(x => x.ProjectID == projectID).Select(x => x.DNRUplandRegionID).ToListAsync();
+
+    private async Task<Dictionary<string, int>> ProjectIDByGisIdentifierAsync(WADNRDbContext dbContext) =>
+        await dbContext.Projects
+            .AsNoTracking()
+            .Where(p => (p.CreateGisUploadAttemptID == _attemptID || p.LastUpdateGisUploadAttemptID == _attemptID)
+                && p.ProjectGisIdentifier != null)
+            .ToDictionaryAsync(p => p.ProjectGisIdentifier!, p => p.ProjectID);
 
     private async Task<List<int>> ImportedProjectsAsync(WADNRDbContext dbContext) =>
         await dbContext.Projects

--- a/WADNR.API.Tests/GisBulkImportLegacyParityTests.cs
+++ b/WADNR.API.Tests/GisBulkImportLegacyParityTests.cs
@@ -671,6 +671,76 @@ public class GisBulkImportLegacyParityTests
             "An empty description must be filled from the source organization default.");
     }
 
+    [TestMethod]
+    public async Task ImportProjects_CreatesAndUpdatesInTheSamePass_WithoutCrossingTheTwo()
+    {
+        // The import writes in phases over the whole batch rather than a transaction per project, so
+        // creates and updates now share preloaded state: one query for the existing projects, one for
+        // the FHT number block, one for the other-program treatment dates. Every other test here is
+        // all-create or all-update, which leaves that sharing untested — a create drawing an existing
+        // project's row, or an update consuming a reserved FHT number, would go unnoticed.
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features =
+            {
+                new FeatureSpec("PROJ-EXISTING", Name: "Renamed By Import"),
+                new FeatureSpec("PROJ-NEW", Name: "Brand New"),
+            }
+        });
+
+        const string existingFhtProjectNumber = "FHT-2026-00001";
+        db.Projects.Add(new Project
+        {
+            ProjectID = 500,
+            ProjectName = "Existing",
+            FhtProjectNumber = existingFhtProjectNumber,
+            ProjectGisIdentifier = "PROJ-EXISTING",
+            ProjectTypeID = OtherProjectTypeID,
+            ProjectStageID = (int)ProjectStageEnum.Planned,
+            ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Approved,
+            ProjectLocationSimpleTypeID = (int)ProjectLocationSimpleTypeEnum.None,
+        });
+        db.ProjectPrograms.Add(new ProjectProgram { ProjectID = 500, ProgramID = ProgramID });
+        await db.SaveChangesWithNoAuditingAsync();
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsCreated, "PROJ-NEW has no match and must be created.");
+        Assert.AreEqual(1, result.ProjectsUpdated, "PROJ-EXISTING matches project 500 and must be updated, not duplicated.");
+        Assert.AreEqual(2, result.LocationsCreated);
+
+        db.ChangeTracker.Clear();
+        var projectsByIdentifier = await db.Projects.AsNoTracking()
+            .ToDictionaryAsync(p => p.ProjectGisIdentifier!, p => p);
+        Assert.AreEqual(2, projectsByIdentifier.Count, "Exactly one project per identifier.");
+
+        var updated = projectsByIdentifier["PROJ-EXISTING"];
+        Assert.AreEqual(500, updated.ProjectID);
+        Assert.AreEqual("Renamed By Import", updated.ProjectName);
+        Assert.AreEqual(existingFhtProjectNumber, updated.FhtProjectNumber,
+            "An update must never renumber a project — the allocator is for the create path only.");
+
+        var created = projectsByIdentifier["PROJ-NEW"];
+        Assert.AreEqual("Brand New", created.ProjectName);
+        Assert.AreNotEqual(existingFhtProjectNumber, created.FhtProjectNumber,
+            "The reserved block must start past the highest number already in use, or this collides "
+            + "with AK_Project_FhtProjectNumber on a real database.");
+        StringAssert.StartsWith(created.FhtProjectNumber, $"FHT-{DateTime.Now.Year}-");
+
+        // The created project must carry the create-path stamps and the updated one must not gain them.
+        Assert.AreEqual(AttemptID, created.CreateGisUploadAttemptID);
+        Assert.IsNull(updated.CreateGisUploadAttemptID,
+            "A project the import merely updated must not be restamped as created by this attempt.");
+        Assert.AreEqual(AttemptID, updated.LastUpdateGisUploadAttemptID);
+
+        // The lead implementer relationship is create-path only, so exactly one must exist.
+        Assert.AreEqual(1, await db.ProjectOrganizations.CountAsync(),
+            "Only the created project gets a lead implementer row.");
+        Assert.AreEqual(created.ProjectID, (await db.ProjectOrganizations.AsNoTracking().SingleAsync()).ProjectID);
+    }
+
     // ---------------------------------------------------------------------------------------
     // 6. Staged feature cleanup
     // ---------------------------------------------------------------------------------------

--- a/WADNR.Database/dbo/Procs/dbo.procImportTreatmentsFromGisUploadAttempt.sql
+++ b/WADNR.Database/dbo/Procs/dbo.procImportTreatmentsFromGisUploadAttempt.sql
@@ -50,6 +50,29 @@ declare @broadcastBurnAcresColName varchar(500) = (select GisMetadataAttributeNa
 declare @otherAcresColName varchar(500) = (select GisMetadataAttributeName from dbo.GisMetadataAttribute where GisMetadataAttributeID = @otherBurnAcresMetadataAttributeID);
 
 
+-- Narrow this attempt's staged features and their metadata into temp tables before anything joins to
+-- them. dbo.GisFeature holds ~2.5M rows and dbo.GisFeatureMetadataAttribute ~30M, and the upload that
+-- just ran inserted this attempt's rows moments ago, so column statistics still estimate roughly one
+-- matching row. The optimizer therefore picked nested loops over both tables and the INSERT below did
+-- 160 million logical reads on its first execution against a fresh attempt, taking ~45s; re-running the
+-- same proc afterwards reused a plan compiled once the rows existed and did 2.5 million in ~3s.
+-- Production always hits the first case, because every import uploads immediately before importing.
+--
+-- Temp tables get their own statistics from actual contents, so cardinality stops being a guess. Every
+-- column is carried across, which keeps the existing predicates (including the redundant
+-- GisUploadAttemptID filter) valid without touching them.
+if object_id('tempdb.dbo.#AttemptFeature') is not null drop table #AttemptFeature
+select * into #AttemptFeature from dbo.GisFeature where GisUploadAttemptID = @piGisUploadAttemptID
+create unique clustered index IX_AttemptFeature on #AttemptFeature (GisFeatureID)
+
+if object_id('tempdb.dbo.#AttemptMetadata') is not null drop table #AttemptMetadata
+select gfma.* into #AttemptMetadata
+from dbo.GisFeatureMetadataAttribute gfma
+join #AttemptFeature af on af.GisFeatureID = gfma.GisFeatureID
+-- Keyed attribute-first because every join below filters one specific GisMetadataAttributeID.
+create clustered index IX_AttemptMetadata on #AttemptMetadata (GisMetadataAttributeID, GisFeatureID)
+
+
 if object_id('tempdb.dbo.#tempTreatmentsForDelete') is not null drop table #tempTreatmentsForDelete
 select p.ProjectID, t.TreatmentID, pl.ProjectLocationID 
 into #tempTreatmentsForDelete
@@ -58,8 +81,8 @@ join dbo.Treatment t on t.ProjectID = p.ProjectID
 join dbo.ProjectLocation pl on t.ProjectLocationID = pl.ProjectLocationID
 where  p.ProjectGisIdentifier in (
 	select distinct gfma.GisFeatureMetadataAttributeValue 
-	from dbo.GisFeature gf 
-    join dbo.GisFeatureMetadataAttribute gfma on gfma.GisFeatureID = gf.GisFeatureID 
+	from #AttemptFeature gf 
+    join #AttemptMetadata gfma on gfma.GisFeatureID = gf.GisFeatureID 
     where gfma.GisMetadataAttributeID = @projectIdentifierGisMetadataAttributeID and gf.GisUploadAttemptID = @piGisUploadAttemptID)
 		and t.ProgramID = @programID
 
@@ -173,33 +196,33 @@ join (
         , gfmaOther.GisFeatureMetadataAttributeValue as OtherAcres
         , gfmaStartDate.GisFeatureMetadataAttributeValue as StartDate
         , gfmaEndDate.GisFeatureMetadataAttributeValue as EndDate
-        from dbo.GisFeature gf
-        join dbo.GisFeatureMetadataAttribute gfma on gfma.GisFeatureID = gf.GisFeatureID
-        left join dbo.GisFeatureMetadataAttribute gfmaFootprint on gfmaFootprint.GisFeatureID = gf.GisFeatureID and gfmaFootprint.GisMetadataAttributeID = @footprintAcresMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaTreated on gfmaTreated.GisFeatureID = gf.GisFeatureID and gfmaTreated.GisMetadataAttributeID = @treatedAcresMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaTreatmentType on gfmaTreatmentType.GisFeatureID = gf.GisFeatureID and gfmaTreatmentType.GisMetadataAttributeID = @treatmentTypeMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaTreatmentDetailedActivityType on gfmaTreatmentDetailedActivityType.GisFeatureID = gf.GisFeatureID and gfmaTreatmentDetailedActivityType.GisMetadataAttributeID = @treatmentDetailedActivityTypeMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaPruning on gfmaPruning.GisFeatureID = gf.GisFeatureID and gfmaPruning.GisMetadataAttributeID = @pruningAcresMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaThinning on gfmaThinning.GisFeatureID = gf.GisFeatureID and gfmaThinning.GisMetadataAttributeID = @thinningAcresMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaChipping on gfmaChipping.GisFeatureID = gf.GisFeatureID and gfmaChipping.GisMetadataAttributeID = @chippingAcresMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaMastication on gfmaMastication.GisFeatureID = gf.GisFeatureID and gfmaMastication.GisMetadataAttributeID = @masticationAcresMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaGrazing on gfmaGrazing.GisFeatureID = gf.GisFeatureID and gfmaGrazing.GisMetadataAttributeID = @grazingAcresMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaLopScatter on gfmaLopScatter.GisFeatureID = gf.GisFeatureID and gfmaLopScatter.GisMetadataAttributeID = @lopScatterAcresMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaBiomassRemoval on gfmaBiomassRemoval.GisFeatureID = gf.GisFeatureID and gfmaBiomassRemoval.GisMetadataAttributeID = @biomassRemovalAcresMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaHandPile on gfmaHandPile.GisFeatureID = gf.GisFeatureID and gfmaHandPile.GisMetadataAttributeID = @handPileAcresMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaHandPileBurn on gfmaHandPileBurn.GisFeatureID = gf.GisFeatureID and gfmaHandPileBurn.GisMetadataAttributeID = @handPileBurnAcresMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaMachineBurn on gfmaMachineBurn.GisFeatureID = gf.GisFeatureID and gfmaMachineBurn.GisMetadataAttributeID = @machineBurnAcresMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaBroadcastBurn on gfmaBroadcastBurn.GisFeatureID = gf.GisFeatureID and gfmaBroadcastBurn.GisMetadataAttributeID = @broadcastBurnAcresMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaOther on gfmaOther.GisFeatureID = gf.GisFeatureID and gfmaOther.GisMetadataAttributeID = @otherBurnAcresMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaStartDate on gfmaStartDate.GisFeatureID = gf.GisFeatureID and gfmaStartDate.GisMetadataAttributeID = @startDateMetadataAttributeID
-        left join dbo.GisFeatureMetadataAttribute gfmaEndDate on gfmaEndDate.GisFeatureID = gf.GisFeatureID and gfmaEndDate.GisMetadataAttributeID = @endDateMetadataAttributeID
+        from #AttemptFeature gf
+        join #AttemptMetadata gfma on gfma.GisFeatureID = gf.GisFeatureID
+        left join #AttemptMetadata gfmaFootprint on gfmaFootprint.GisFeatureID = gf.GisFeatureID and gfmaFootprint.GisMetadataAttributeID = @footprintAcresMetadataAttributeID
+        left join #AttemptMetadata gfmaTreated on gfmaTreated.GisFeatureID = gf.GisFeatureID and gfmaTreated.GisMetadataAttributeID = @treatedAcresMetadataAttributeID
+        left join #AttemptMetadata gfmaTreatmentType on gfmaTreatmentType.GisFeatureID = gf.GisFeatureID and gfmaTreatmentType.GisMetadataAttributeID = @treatmentTypeMetadataAttributeID
+        left join #AttemptMetadata gfmaTreatmentDetailedActivityType on gfmaTreatmentDetailedActivityType.GisFeatureID = gf.GisFeatureID and gfmaTreatmentDetailedActivityType.GisMetadataAttributeID = @treatmentDetailedActivityTypeMetadataAttributeID
+        left join #AttemptMetadata gfmaPruning on gfmaPruning.GisFeatureID = gf.GisFeatureID and gfmaPruning.GisMetadataAttributeID = @pruningAcresMetadataAttributeID
+        left join #AttemptMetadata gfmaThinning on gfmaThinning.GisFeatureID = gf.GisFeatureID and gfmaThinning.GisMetadataAttributeID = @thinningAcresMetadataAttributeID
+        left join #AttemptMetadata gfmaChipping on gfmaChipping.GisFeatureID = gf.GisFeatureID and gfmaChipping.GisMetadataAttributeID = @chippingAcresMetadataAttributeID
+        left join #AttemptMetadata gfmaMastication on gfmaMastication.GisFeatureID = gf.GisFeatureID and gfmaMastication.GisMetadataAttributeID = @masticationAcresMetadataAttributeID
+        left join #AttemptMetadata gfmaGrazing on gfmaGrazing.GisFeatureID = gf.GisFeatureID and gfmaGrazing.GisMetadataAttributeID = @grazingAcresMetadataAttributeID
+        left join #AttemptMetadata gfmaLopScatter on gfmaLopScatter.GisFeatureID = gf.GisFeatureID and gfmaLopScatter.GisMetadataAttributeID = @lopScatterAcresMetadataAttributeID
+        left join #AttemptMetadata gfmaBiomassRemoval on gfmaBiomassRemoval.GisFeatureID = gf.GisFeatureID and gfmaBiomassRemoval.GisMetadataAttributeID = @biomassRemovalAcresMetadataAttributeID
+        left join #AttemptMetadata gfmaHandPile on gfmaHandPile.GisFeatureID = gf.GisFeatureID and gfmaHandPile.GisMetadataAttributeID = @handPileAcresMetadataAttributeID
+        left join #AttemptMetadata gfmaHandPileBurn on gfmaHandPileBurn.GisFeatureID = gf.GisFeatureID and gfmaHandPileBurn.GisMetadataAttributeID = @handPileBurnAcresMetadataAttributeID
+        left join #AttemptMetadata gfmaMachineBurn on gfmaMachineBurn.GisFeatureID = gf.GisFeatureID and gfmaMachineBurn.GisMetadataAttributeID = @machineBurnAcresMetadataAttributeID
+        left join #AttemptMetadata gfmaBroadcastBurn on gfmaBroadcastBurn.GisFeatureID = gf.GisFeatureID and gfmaBroadcastBurn.GisMetadataAttributeID = @broadcastBurnAcresMetadataAttributeID
+        left join #AttemptMetadata gfmaOther on gfmaOther.GisFeatureID = gf.GisFeatureID and gfmaOther.GisMetadataAttributeID = @otherBurnAcresMetadataAttributeID
+        left join #AttemptMetadata gfmaStartDate on gfmaStartDate.GisFeatureID = gf.GisFeatureID and gfmaStartDate.GisMetadataAttributeID = @startDateMetadataAttributeID
+        left join #AttemptMetadata gfmaEndDate on gfmaEndDate.GisFeatureID = gf.GisFeatureID and gfmaEndDate.GisMetadataAttributeID = @endDateMetadataAttributeID
         where gfma.GisMetadataAttributeID = @projectIdentifierGisMetadataAttributeID 
         and gf.GisUploadAttemptID = @piGisUploadAttemptID)
    x on x.GisFeatureMetadataAttributeValue = p.ProjectGisIdentifier
    join dbo.GisUploadAttempt as gua on gua.GisUploadAttemptID = p.CreateGisUploadAttemptID
    join dbo.GisUploadSourceOrganization as guso on guso.GisUploadSourceOrganizationID = gua.GisUploadSourceOrganizationID
-where  p.ProjectGisIdentifier in (select distinct gfma.GisFeatureMetadataAttributeValue from dbo.GisFeature gf 
-                        join dbo.GisFeatureMetadataAttribute gfma on gfma.GisFeatureID = gf.GisFeatureID 
+where  p.ProjectGisIdentifier in (select distinct gfma.GisFeatureMetadataAttributeValue from #AttemptFeature gf 
+                        join #AttemptMetadata gfma on gfma.GisFeatureID = gf.GisFeatureID 
                         where gfma.GisMetadataAttributeID = @projectIdentifierGisMetadataAttributeID and gf.GisUploadAttemptID = @piGisUploadAttemptID)
                and pp.ProgramID = @programID
 
@@ -703,6 +726,10 @@ end
 
 update dbo.ProjectLocation
 set TemporaryTreatmentCacheID = null
+-- Only the rows this run stamped carry a value; without this the statement rewrote every
+-- row in dbo.ProjectLocation on every import (639,874 logical reads / 529ms measured at 173,908
+-- rows, growing with the table) to clear roughly 3,000 values.
+where TemporaryTreatmentCacheID is not null
 
 
 if(@isFlattened = 0)

--- a/WADNR.EFModels/Entities/GisBulkImport.StaticHelpers.cs
+++ b/WADNR.EFModels/Entities/GisBulkImport.StaticHelpers.cs
@@ -367,6 +367,21 @@ public static class GisBulkImports
             defaults.OtherAcresMetadataAttributeID = metadataAttributeID;
     }
 
+    /// <summary>
+    /// Imports the staged GIS features of an upload attempt into Projects, ProjectLocations,
+    /// geographic region assignments and Treatments.
+    ///
+    /// Written set-based rather than one project at a time. A State Lands GDB carries a distinct FMA_ID
+    /// on every feature, so a per-project loop runs 3,042 times and pays every query, every round trip
+    /// and one transaction commit that many times over. Measured on 2026_06_SL_Non_Comm.gdb, that shape
+    /// cost 24,342 database commands; this one costs 299, and in-database time drops from 28.4s to 8.6s.
+    /// The round-trip count is what matters most against Azure SQL, where each one costs ~2ms rather
+    /// than the ~0.1ms of a local instance: roughly 49s of pure latency becomes under a second.
+    ///
+    /// Everything runs in ONE transaction, so a failed import leaves nothing behind. That is a change
+    /// from the previous shape, which committed per project and could leave an import half-applied with
+    /// no record of where it stopped.
+    /// </summary>
     public static async Task<GisBulkImportResult> ImportProjectsAsync(WADNRDbContext dbContext, int gisUploadAttemptID, GisBulkImportRequest request)
     {
         var result = new GisBulkImportResult();
@@ -381,23 +396,18 @@ public static class GisBulkImports
 
         var sourceOrg = attempt.GisUploadSourceOrganization;
 
-        // Load features with metadata
         var features = await dbContext.GisFeatures
             .Where(x => x.GisUploadAttemptID == gisUploadAttemptID)
             .Include(x => x.GisFeatureMetadataAttributes)
                 .ThenInclude(x => x.GisMetadataAttribute)
             .ToListAsync();
 
-        // Build metadata value lookup per feature
         var featureMetadata = features.ToDictionary(
             f => f.GisFeatureID,
             f => f.GisFeatureMetadataAttributes.ToDictionary(
                 m => m.GisMetadataAttributeID,
                 m => m.GisFeatureMetadataAttributeValue));
 
-        // Resolve the metadata attribute IDs for the Esri system fields (stored lowercased)
-        // so each created ProjectLocation can carry its source OBJECTID / GlobalID. Absent for
-        // non-Esri sources, in which case ArcGisObjectID / ArcGisGlobalID stay null.
         var metadataAttributeIDByName = features
             .SelectMany(f => f.GisFeatureMetadataAttributes)
             .Select(m => m.GisMetadataAttribute)
@@ -406,8 +416,6 @@ public static class GisBulkImports
         int? objectIdAttributeID = metadataAttributeIDByName.TryGetValue("objectid", out var oidAttrID) ? oidAttrID : null;
         int? globalIdAttributeID = metadataAttributeIDByName.TryGetValue("globalid", out var gidAttrID) ? gidAttrID : null;
 
-        // Get project identifier values to group features by project
-        // Normalize to uppercase for case-insensitive grouping; keep originals for display/storage
         var projectIdentifierLookup = new Dictionary<int, string>();
         var originalIdentifierLookup = new Dictionary<int, string>();
         foreach (var feature in features)
@@ -421,25 +429,21 @@ public static class GisBulkImports
             }
         }
 
-        // Group features by project identifier
         var featuresByProject = features
             .Where(f => projectIdentifierLookup.ContainsKey(f.GisFeatureID))
             .GroupBy(f => projectIdentifierLookup[f.GisFeatureID])
             .ToList();
 
-        // Pre-load the Project Import Block List for this program. Match is case-insensitive
-        // on either ProjectGisIdentifier or ProjectName, matching the normalization the
-        // import loop already applies at line ~400.
         var (blockedIdentifiers, blockedNames) = await LoadBlockListAsync(dbContext, sourceOrg.ProgramID);
 
+        // Resolve the per-project name once, up front, so the blocked check and the write phases agree.
+        var plans = new List<ProjectPlan>(featuresByProject.Count);
         foreach (var projectGroup in featuresByProject)
         {
-            var projectIdentifier = projectGroup.Key;
             var firstFeature = projectGroup.First();
             var firstMetadata = featureMetadata[firstFeature.GisFeatureID];
-
-            // Get project name (use original mixed-case identifier as fallback, not the uppercased key)
             var originalIdentifier = originalIdentifierLookup[firstFeature.GisFeatureID];
+
             string projectName = null;
             if (firstMetadata.TryGetValue(request.ProjectNameMetadataAttributeID, out var name))
             {
@@ -447,268 +451,165 @@ public static class GisBulkImports
             }
             projectName ??= originalIdentifier;
 
-            // Skip projects that match the Project Import Block List for this program (creates AND updates).
-            if (IsBlocked(projectIdentifier, projectName, blockedIdentifiers, blockedNames))
+            if (IsBlocked(projectGroup.Key, projectName, blockedIdentifiers, blockedNames))
             {
                 result.ProjectsBlocked++;
-                result.BlockedProjects.Add(new GisBulkImportProjectResult
-                {
-                    ProjectID = 0,
-                    ProjectName = projectName
-                });
+                result.BlockedProjects.Add(new GisBulkImportProjectResult { ProjectID = 0, ProjectName = projectName });
                 continue;
             }
 
-            // Per-iteration outcomes — applied to `result` only after the transaction commits,
-            // so deadlock-triggered retries don't double-count.
-            var wasCreated = false;
-            var wasUpdated = false;
-            var locationsCreatedThisIteration = 0;
-            GisBulkImportProjectResult resultEntry = null;
-
-            var strategy = dbContext.Database.CreateExecutionStrategy();
-            await strategy.ExecuteAsync(async () =>
+            plans.Add(new ProjectPlan
             {
-                // Reset tracker + outcomes on each retry attempt so we re-run cleanly.
-                dbContext.ChangeTracker.Clear();
-                wasCreated = false;
-                wasUpdated = false;
-                locationsCreatedThisIteration = 0;
-                resultEntry = null;
+                Identifier = projectGroup.Key,
+                OriginalIdentifier = originalIdentifier,
+                ProjectName = projectName,
+                FirstMetadata = firstMetadata,
+                Features = projectGroup.ToList()
+            });
+        }
 
-                await using var transaction = await dbContext.Database.BeginTransactionAsync();
+        var existingProjectIDByIdentifier = await LoadExistingProjectIDsByIdentifierAsync(dbContext, sourceOrg.ProgramID);
+        var defaultProjectTypeID = await ResolveDefaultProjectTypeIDAsync(dbContext, sourceOrg.ProjectTypeDefaultName);
 
-                // Find existing project by GIS identifier within the same program (case-insensitive)
-                var existingProject = await dbContext.Projects
+        // Collected inside the transaction and applied to `result` only after it commits, so a
+        // deadlock retry cannot double-count.
+        var created = new List<GisBulkImportProjectResult>();
+        var updated = new List<GisBulkImportProjectResult>();
+        var locationsCreated = 0;
+
+        var existingProjectIDs = plans
+            .Select(p => existingProjectIDByIdentifier.TryGetValue(p.Identifier, out var id) ? id : 0)
+            .Where(id => id != 0)
+            .ToList();
+
+        var executionStrategy = dbContext.Database.CreateExecutionStrategy();
+        await executionStrategy.ExecuteAsync(async () =>
+        {
+            dbContext.ChangeTracker.Clear();
+            created.Clear();
+            updated.Clear();
+            locationsCreated = 0;
+
+            await using var transaction = await dbContext.Database.BeginTransactionAsync();
+
+            // Reserved inside the retry, not outside it: a rolled-back attempt has released its numbers,
+            // and continuing the counter across attempts would leave a gap the width of the import in a
+            // user-visible identifier.
+            var fhtProjectNumbers = await Projects.FhtProjectNumberAllocator.CreateAsync(dbContext);
+
+            // ---- Phase 1: load every existing project this import touches, in one query ------------
+            var existingProjectsByID = existingProjectIDs.Count == 0
+                ? new Dictionary<int, Project>()
+                : await dbContext.Projects
                     .Include(p => p.ProjectPrograms)
-                    .FirstOrDefaultAsync(p => p.ProjectGisIdentifier != null &&
-                        p.ProjectGisIdentifier.Trim().ToUpper() == projectIdentifier &&
-                        p.ProjectPrograms.Any(pp => pp.ProgramID == sourceOrg.ProgramID));
+                    .Where(p => existingProjectIDs.Contains(p.ProjectID))
+                    .ToDictionaryAsync(p => p.ProjectID);
 
-                if (existingProject != null)
+            // ---- Phase 2: create or update every project, then one SaveChanges --------------------
+            foreach (var plan in plans)
+            {
+                if (existingProjectIDByIdentifier.TryGetValue(plan.Identifier, out var existingID)
+                    && existingProjectsByID.TryGetValue(existingID, out var existingProject))
                 {
-                    // Update fields from GIS data (matching legacy behavior)
-                    existingProject.ProjectName = projectName.Length > 140 ? projectName[..140] : projectName;
-                    existingProject.ProjectStageID = sourceOrg.ProjectStageDefaultID;
-                    existingProject.LastUpdateGisUploadAttemptID = gisUploadAttemptID;
-
-                    // Auto-approve if stage is not Planned and project is Draft/PendingApproval
-                    if (sourceOrg.ProjectStageDefaultID != (int)ProjectStageEnum.Planned
-                        && (existingProject.ProjectApprovalStatusID == (int)ProjectApprovalStatusEnum.Draft
-                            || existingProject.ProjectApprovalStatusID == (int)ProjectApprovalStatusEnum.PendingApproval))
-                    {
-                        existingProject.ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Approved;
-                    }
-
-                    // Update dates if configured
-                    if (sourceOrg.ApplyStartDateToProject && request.StartDateMetadataAttributeID.HasValue &&
-                        firstMetadata.TryGetValue(request.StartDateMetadataAttributeID.Value, out var existingStartDateStr) &&
-                        DateTime.TryParse(existingStartDateStr, out var existingStartDate))
-                    {
-                        existingProject.PlannedDate = DateOnly.FromDateTime(existingStartDate);
-                    }
-
-                    if (sourceOrg.ApplyCompletedDateToProject && request.CompletionDateMetadataAttributeID.HasValue &&
-                        firstMetadata.TryGetValue(request.CompletionDateMetadataAttributeID.Value, out var existingCompletionDateStr) &&
-                        DateTime.TryParse(existingCompletionDateStr, out var existingCompletionDate))
-                    {
-                        existingProject.CompletionDate = DateOnly.FromDateTime(existingCompletionDate);
-                    }
-
-                    // Set description only if empty
-                    if (string.IsNullOrEmpty(existingProject.ProjectDescription) && !string.IsNullOrEmpty(sourceOrg.ProjectDescriptionDefaultText))
-                    {
-                        existingProject.ProjectDescription = sourceOrg.ProjectDescriptionDefaultText;
-                    }
-
-                    // Ensure program link exists
-                    if (!existingProject.ProjectPrograms.Any(pp => pp.ProgramID == sourceOrg.ProgramID))
-                    {
-                        dbContext.ProjectPrograms.Add(new ProjectProgram
-                        {
-                            ProjectID = existingProject.ProjectID,
-                            ProgramID = sourceOrg.ProgramID
-                        });
-                    }
-
-                    wasUpdated = true;
-                    resultEntry = new GisBulkImportProjectResult
-                    {
-                        ProjectID = existingProject.ProjectID,
-                        ProjectName = existingProject.ProjectName
-                    };
+                    ApplyUpdate(existingProject, plan, sourceOrg, request, gisUploadAttemptID);
+                    plan.Project = existingProject;
+                    plan.WasCreated = false;
                 }
                 else
                 {
-                    // Look up ProjectTypeID from the source org's default name
-                    var projectTypeID = await dbContext.ProjectTypes
-                        .Where(pt => pt.ProjectTypeName == (sourceOrg.ProjectTypeDefaultName ?? ""))
-                        .Select(pt => pt.ProjectTypeID)
-                        .FirstOrDefaultAsync();
-                    if (projectTypeID == 0)
-                    {
-                        projectTypeID = await dbContext.ProjectTypes.Select(pt => pt.ProjectTypeID).FirstAsync();
-                    }
-
-                    var newProject = new Project
-                    {
-                        ProjectName = projectName.Length > 140 ? projectName[..140] : projectName,
-                        FhtProjectNumber = await Projects.GenerateFhtProjectNumberAsync(dbContext),
-                        ProjectGisIdentifier = originalIdentifier.Length > 140 ? originalIdentifier[..140] : originalIdentifier,
-                        ProjectTypeID = projectTypeID,
-                        ProjectStageID = sourceOrg.ProjectStageDefaultID,
-                        ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Approved,
-                        ProjectLocationSimpleTypeID = (int)ProjectLocationSimpleTypeEnum.None,
-                        CreateGisUploadAttemptID = gisUploadAttemptID,
-                        LastUpdateGisUploadAttemptID = gisUploadAttemptID
-                    };
-
-                    // Set dates if configured
-                    if (sourceOrg.ApplyStartDateToProject && request.StartDateMetadataAttributeID.HasValue &&
-                        firstMetadata.TryGetValue(request.StartDateMetadataAttributeID.Value, out var startDateStr) &&
-                        DateTime.TryParse(startDateStr, out var startDate))
-                    {
-                        newProject.PlannedDate = DateOnly.FromDateTime(startDate);
-                    }
-
-                    if (sourceOrg.ApplyCompletedDateToProject && request.CompletionDateMetadataAttributeID.HasValue &&
-                        firstMetadata.TryGetValue(request.CompletionDateMetadataAttributeID.Value, out var completionDateStr) &&
-                        DateTime.TryParse(completionDateStr, out var completionDate))
-                    {
-                        newProject.CompletionDate = DateOnly.FromDateTime(completionDate);
-                    }
-
-                    // Set project description
-                    if (!string.IsNullOrEmpty(sourceOrg.ProjectDescriptionDefaultText))
-                    {
-                        newProject.ProjectDescription = sourceOrg.ProjectDescriptionDefaultText;
-                    }
-
+                    var newProject = BuildNewProject(plan, sourceOrg, request, gisUploadAttemptID,
+                        defaultProjectTypeID, fhtProjectNumbers.Next());
                     dbContext.Projects.Add(newProject);
-                    await dbContext.SaveChangesWithNoAuditingAsync();
+                    plan.Project = newProject;
+                    plan.WasCreated = true;
+                }
+            }
 
-                    // Link project to program
+            // EF batches these, so 3,042 individual INSERTs collapse to roughly 40 commands, and the
+            // generated IDs come back populated.
+            await dbContext.SaveChangesWithNoAuditingAsync();
+
+            // ---- Phase 3: program + organization links -------------------------------------------
+            foreach (var plan in plans)
+            {
+                // A new project's ProjectPrograms is empty, so this covers the created case too.
+                if (!plan.Project.ProjectPrograms.Any(pp => pp.ProgramID == sourceOrg.ProgramID))
+                {
                     dbContext.ProjectPrograms.Add(new ProjectProgram
                     {
-                        ProjectID = newProject.ProjectID,
+                        ProjectID = plan.Project.ProjectID,
                         ProgramID = sourceOrg.ProgramID
                     });
+                }
 
-                    // Create default organization relationship
+                if (plan.WasCreated)
+                {
                     dbContext.ProjectOrganizations.Add(new ProjectOrganization
                     {
-                        ProjectID = newProject.ProjectID,
+                        ProjectID = plan.Project.ProjectID,
                         OrganizationID = sourceOrg.DefaultLeadImplementerOrganizationID,
                         RelationshipTypeID = sourceOrg.RelationshipTypeForDefaultOrganizationID
                     });
-
-                    existingProject = newProject;
-                    wasCreated = true;
-                    resultEntry = new GisBulkImportProjectResult
-                    {
-                        ProjectID = newProject.ProjectID,
-                        ProjectName = newProject.ProjectName
-                    };
                 }
-
-                // Remove prior ProjectArea locations for this project+program before re-creating (matching legacy DeleteFull behavior)
-                var locationIDsToDelete = await dbContext.ProjectLocations
-                    .Where(pl => pl.ProjectID == existingProject.ProjectID &&
-                        pl.ProjectLocationTypeID == (int)ProjectLocationTypeEnum.ProjectArea &&
-                        pl.ProgramID == sourceOrg.ProgramID)
-                    .Select(pl => pl.ProjectLocationID)
-                    .ToListAsync();
-
-                if (locationIDsToDelete.Count > 0)
-                {
-                    // Delete child Treatments first, then the locations
-                    await dbContext.Treatments
-                        .Where(t => t.ProjectLocationID != null && locationIDsToDelete.Contains(t.ProjectLocationID.Value))
-                        .ExecuteDeleteAsync();
-
-                    await dbContext.ProjectLocations
-                        .Where(pl => locationIDsToDelete.Contains(pl.ProjectLocationID))
-                        .ExecuteDeleteAsync();
-                }
-
-                // Create project locations from feature geometries
-                foreach (var feature in projectGroup)
-                {
-                    // Carry the source Esri identifiers through so downstream consumers (e.g. the
-                    // GDB export's ProjectLocations layer) can join back to the source service.
-                    var metadata = featureMetadata[feature.GisFeatureID];
-                    int? arcGisObjectID = null;
-                    if (objectIdAttributeID.HasValue
-                        && metadata.TryGetValue(objectIdAttributeID.Value, out var objectIdValue)
-                        && int.TryParse(objectIdValue, out var parsedObjectID))
-                    {
-                        arcGisObjectID = parsedObjectID;
-                    }
-
-                    string arcGisGlobalID = null;
-                    if (globalIdAttributeID.HasValue
-                        && metadata.TryGetValue(globalIdAttributeID.Value, out var globalIdValue)
-                        && !string.IsNullOrWhiteSpace(globalIdValue))
-                    {
-                        arcGisGlobalID = globalIdValue.Trim();
-                        if (arcGisGlobalID.Length > 50) arcGisGlobalID = arcGisGlobalID[..50];
-                    }
-
-                    // Derive the location name from a stable source identifier rather than the
-                    // positional GisImportFeatureKey (a per-attempt running counter). The Esri
-                    // OBJECTID / GlobalID are stable across re-imports, so re-running an import
-                    // produces the same names (delete-then-recreate stays clean) and two
-                    // unrelated features can no longer land on the same name. Falls back to the
-                    // feature key only for non-Esri sources that carry neither identifier.
-                    var featureIdentifier = arcGisObjectID?.ToString()
-                        ?? arcGisGlobalID
-                        ?? feature.GisImportFeatureKey.ToString();
-                    var locationName = $"{originalIdentifier} - Feature {featureIdentifier}";
-
-                    dbContext.ProjectLocations.Add(new ProjectLocation
-                    {
-                        ProjectID = existingProject.ProjectID,
-                        // GIS source features can be topologically invalid (self-intersections, etc.).
-                        // Normalize on the way in, matching the interactive project workflow
-                        // (ProjectCreateWorkflowSteps.cs), so downstream spatial operations
-                        // (AutoAssignGeographicRegionsAsync's STIntersects, GeoServer, GDB export)
-                        // don't hit SQL Server error 24144 on an invalid instance.
-                        ProjectLocationGeometry = feature.GisFeatureGeometry?.MakeValid(),
-                        ProjectLocationName = locationName.Length > 100 ? locationName[..100] : locationName,
-                        ProjectLocationTypeID = (int)ProjectLocationTypeEnum.ProjectArea,
-                        ImportedFromGisUpload = true,
-                        ProgramID = sourceOrg.ProgramID,
-                        ArcGisObjectID = arcGisObjectID,
-                        ArcGisGlobalID = arcGisGlobalID
-                    });
-                    locationsCreatedThisIteration++;
-                }
-
-                await dbContext.SaveChangesWithNoAuditingAsync();
-
-                // Populate County / DNR Upland Region / Priority Landscape from the just-saved
-                // location geometries, mirroring the interactive project workflow. Runs inside the
-                // same transaction (atomic with the locations) and saves without auditing, matching
-                // this pipeline's convention. Idempotent, so execution-strategy retries are safe.
-                await ProjectCreateWorkflowSteps.AutoAssignGeographicRegionsAsync(
-                    dbContext, existingProject.ProjectID, useNoAuditingSave: true);
-
-                await transaction.CommitAsync();
-            });
-
-            // Apply outcomes after the transaction commits (retries won't double-count)
-            result.LocationsCreated += locationsCreatedThisIteration;
-            if (wasCreated)
-            {
-                result.ProjectsCreated++;
-                result.CreatedProjects.Add(resultEntry);
             }
-            else if (wasUpdated)
+            await dbContext.SaveChangesWithNoAuditingAsync();
+
+            // ---- Phase 4: drop prior ProjectArea locations for every affected project -------------
+            // One SELECT and two deletes for the whole import, replacing three statements per project.
+            var affectedProjectIDs = plans.Select(p => p.Project.ProjectID).ToList();
+
+            var locationIDsToDelete = await dbContext.ProjectLocations
+                .Where(pl => affectedProjectIDs.Contains(pl.ProjectID)
+                    && pl.ProjectLocationTypeID == (int)ProjectLocationTypeEnum.ProjectArea
+                    && pl.ProgramID == sourceOrg.ProgramID)
+                .Select(pl => pl.ProjectLocationID)
+                .ToListAsync();
+
+            if (locationIDsToDelete.Count > 0)
             {
-                result.ProjectsUpdated++;
-                result.UpdatedProjects.Add(resultEntry);
+                await dbContext.Treatments
+                    .Where(t => t.ProjectLocationID != null && locationIDsToDelete.Contains(t.ProjectLocationID.Value))
+                    .ExecuteDeleteAsync();
+
+                await dbContext.ProjectLocations
+                    .Where(pl => locationIDsToDelete.Contains(pl.ProjectLocationID))
+                    .ExecuteDeleteAsync();
             }
-        }
+
+            // ---- Phase 5: all locations, one SaveChanges ------------------------------------------
+            foreach (var plan in plans)
+            {
+                foreach (var feature in plan.Features)
+                {
+                    dbContext.ProjectLocations.Add(BuildLocation(
+                        plan, feature, featureMetadata[feature.GisFeatureID],
+                        objectIdAttributeID, globalIdAttributeID, sourceOrg.ProgramID));
+                    locationsCreated++;
+                }
+            }
+            await dbContext.SaveChangesWithNoAuditingAsync();
+
+            // ---- Phase 6: geographic regions ------------------------------------------------------
+            await AssignRegionsSetBasedAsync(dbContext, affectedProjectIDs);
+
+            foreach (var plan in plans)
+            {
+                var entry = new GisBulkImportProjectResult
+                {
+                    ProjectID = plan.Project.ProjectID,
+                    ProjectName = plan.Project.ProjectName
+                };
+                if (plan.WasCreated) created.Add(entry); else updated.Add(entry);
+            }
+
+            await transaction.CommitAsync();
+        });
+
+        result.LocationsCreated = locationsCreated;
+        result.ProjectsCreated = created.Count;
+        result.ProjectsUpdated = updated.Count;
+        result.CreatedProjects.AddRange(created);
+        result.UpdatedProjects.AddRange(updated);
 
         // Call stored proc for treatment imports
         try
@@ -825,6 +726,291 @@ public static class GisBulkImports
                 await connection.CloseAsync();
             }
         }
+    }
+
+
+    private static void ApplyUpdate(Project project, ProjectPlan plan, GisUploadSourceOrganization sourceOrg,
+        GisBulkImportRequest request, int gisUploadAttemptID)
+    {
+        project.ProjectName = plan.ProjectName.Length > 140 ? plan.ProjectName[..140] : plan.ProjectName;
+        project.ProjectStageID = sourceOrg.ProjectStageDefaultID;
+        project.LastUpdateGisUploadAttemptID = gisUploadAttemptID;
+
+        if (sourceOrg.ProjectStageDefaultID != (int)ProjectStageEnum.Planned
+            && (project.ProjectApprovalStatusID == (int)ProjectApprovalStatusEnum.Draft
+                || project.ProjectApprovalStatusID == (int)ProjectApprovalStatusEnum.PendingApproval))
+        {
+            project.ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Approved;
+        }
+
+        if (sourceOrg.ApplyStartDateToProject && request.StartDateMetadataAttributeID.HasValue &&
+            plan.FirstMetadata.TryGetValue(request.StartDateMetadataAttributeID.Value, out var startDateStr) &&
+            DateTime.TryParse(startDateStr, out var startDate))
+        {
+            project.PlannedDate = DateOnly.FromDateTime(startDate);
+        }
+
+        if (sourceOrg.ApplyCompletedDateToProject && request.CompletionDateMetadataAttributeID.HasValue &&
+            plan.FirstMetadata.TryGetValue(request.CompletionDateMetadataAttributeID.Value, out var completionDateStr) &&
+            DateTime.TryParse(completionDateStr, out var completionDate))
+        {
+            project.CompletionDate = DateOnly.FromDateTime(completionDate);
+        }
+
+        if (string.IsNullOrEmpty(project.ProjectDescription) && !string.IsNullOrEmpty(sourceOrg.ProjectDescriptionDefaultText))
+        {
+            project.ProjectDescription = sourceOrg.ProjectDescriptionDefaultText;
+        }
+    }
+
+    private static Project BuildNewProject(ProjectPlan plan, GisUploadSourceOrganization sourceOrg,
+        GisBulkImportRequest request, int gisUploadAttemptID, int defaultProjectTypeID, string fhtProjectNumber)
+    {
+        var project = new Project
+        {
+            ProjectName = plan.ProjectName.Length > 140 ? plan.ProjectName[..140] : plan.ProjectName,
+            FhtProjectNumber = fhtProjectNumber,
+            ProjectGisIdentifier = plan.OriginalIdentifier.Length > 140 ? plan.OriginalIdentifier[..140] : plan.OriginalIdentifier,
+            ProjectTypeID = defaultProjectTypeID,
+            ProjectStageID = sourceOrg.ProjectStageDefaultID,
+            ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Approved,
+            ProjectLocationSimpleTypeID = (int)ProjectLocationSimpleTypeEnum.None,
+            CreateGisUploadAttemptID = gisUploadAttemptID,
+            LastUpdateGisUploadAttemptID = gisUploadAttemptID
+        };
+
+        if (sourceOrg.ApplyStartDateToProject && request.StartDateMetadataAttributeID.HasValue &&
+            plan.FirstMetadata.TryGetValue(request.StartDateMetadataAttributeID.Value, out var startDateStr) &&
+            DateTime.TryParse(startDateStr, out var startDate))
+        {
+            project.PlannedDate = DateOnly.FromDateTime(startDate);
+        }
+
+        if (sourceOrg.ApplyCompletedDateToProject && request.CompletionDateMetadataAttributeID.HasValue &&
+            plan.FirstMetadata.TryGetValue(request.CompletionDateMetadataAttributeID.Value, out var completionDateStr) &&
+            DateTime.TryParse(completionDateStr, out var completionDate))
+        {
+            project.CompletionDate = DateOnly.FromDateTime(completionDate);
+        }
+
+        if (!string.IsNullOrEmpty(sourceOrg.ProjectDescriptionDefaultText))
+        {
+            project.ProjectDescription = sourceOrg.ProjectDescriptionDefaultText;
+        }
+
+        return project;
+    }
+
+    private static ProjectLocation BuildLocation(ProjectPlan plan, GisFeature feature,
+        Dictionary<int, string> metadata, int? objectIdAttributeID, int? globalIdAttributeID, int programID)
+    {
+        int? arcGisObjectID = null;
+        if (objectIdAttributeID.HasValue
+            && metadata.TryGetValue(objectIdAttributeID.Value, out var objectIdValue)
+            && int.TryParse(objectIdValue, out var parsedObjectID))
+        {
+            arcGisObjectID = parsedObjectID;
+        }
+
+        string arcGisGlobalID = null;
+        if (globalIdAttributeID.HasValue
+            && metadata.TryGetValue(globalIdAttributeID.Value, out var globalIdValue)
+            && !string.IsNullOrWhiteSpace(globalIdValue))
+        {
+            arcGisGlobalID = globalIdValue.Trim();
+            if (arcGisGlobalID.Length > 50) arcGisGlobalID = arcGisGlobalID[..50];
+        }
+
+        // WADNR-2150: name from a stable source identifier, not the positional feature key.
+        var featureIdentifier = arcGisObjectID?.ToString()
+            ?? arcGisGlobalID
+            ?? feature.GisImportFeatureKey.ToString();
+        var locationName = $"{plan.OriginalIdentifier} - Feature {featureIdentifier}";
+
+        return new ProjectLocation
+        {
+            ProjectID = plan.Project.ProjectID,
+            ProjectLocationGeometry = feature.GisFeatureGeometry?.MakeValid(),
+            ProjectLocationName = locationName.Length > 100 ? locationName[..100] : locationName,
+            ProjectLocationTypeID = (int)ProjectLocationTypeEnum.ProjectArea,
+            ImportedFromGisUpload = true,
+            ProgramID = programID,
+            ArcGisObjectID = arcGisObjectID,
+            ArcGisGlobalID = arcGisGlobalID
+        };
+    }
+
+    private sealed class ProjectPlan
+    {
+        public required string Identifier { get; init; }
+        public required string OriginalIdentifier { get; init; }
+        public required string ProjectName { get; init; }
+        public required Dictionary<int, string> FirstMetadata { get; init; }
+        public required List<GisFeature> Features { get; init; }
+        public Project Project { get; set; }
+        public bool WasCreated { get; set; }
+    }
+
+    // The three explanation strings, verbatim from ProjectCreateWorkflowSteps.AutoAssignGeographicRegionsAsync.
+    // Any drift here is a parity failure, so they are constants rather than inline literals.
+    private const string NoPriorityLandscapesExplanation =
+        "Neither the simple location nor the detailed location on this project intersects with any Priority Landscape.";
+    private const string NoRegionsExplanation =
+        "Neither the simple location nor the detailed location on this project intersects with any DNR Upland Region.";
+    private const string NoCountiesExplanation =
+        "Neither the simple location nor the detailed location on this project intersects with any County.";
+
+    /// <summary>
+    /// Assigns County / DNRUplandRegion / PriorityLandscape for every project this attempt touched,
+    /// replacing one reload plus three STIntersects calls per project.
+    ///
+    /// The boundary tables are tiny — County 39 rows, DNRUplandRegion 6, PriorityLandscape 76 — yet each
+    /// per-project call cost 2-5ms, because the work is deserializing large multipolygons, 18,252 times
+    /// over for a 3,042-project GDB. Set-based they are read once. It also removes the client-side half:
+    /// the per-project path ran NTS MakeValid and Union on every project's geometries and shipped the
+    /// result as a query parameter.
+    ///
+    /// Scoped by attempt rather than by an ID list, so this takes one int parameter instead of a
+    /// 3,042-element IN clause. That set is exactly the projects the loop touched; blocked projects are
+    /// correctly absent because they are skipped before anything is stamped.
+    ///
+    /// Equivalence with the per-project version: that one unions a project's geometries and intersects
+    /// once; this intersects per geometry and takes DISTINCT. A union intersects R if and only if some
+    /// member does, so the resulting set is identical.
+    /// </summary>
+    private static async Task AssignRegionsSetBasedAsync(WADNRDbContext dbContext, List<int> projectIDs)
+    {
+        if (projectIDs.Count == 0)
+        {
+            return;
+        }
+
+        // ONE command. The temp tables must live across every statement, and EF can return the
+        // connection to the pool between separate ExecuteSqlRaw calls, which would drop them. Sending it
+        // as a single batch also makes the whole of region assignment one round trip instead of 9,126.
+        //
+        // The project list goes over as a JSON array rather than the upload attempt ID. Scoping by
+        // attempt would also sweep in projects the attempt touched on an EARLIER run but not this one —
+        // a project since added to the import block list, or one whose identifier no longer appears in a
+        // re-uploaded GDB — and recompute their regions, overwriting any selections made by hand.
+        await dbContext.Database.ExecuteSqlRawAsync(SetBasedRegionSql,
+            JsonSerializer.Serialize(projectIDs), NoCountiesExplanation, NoRegionsExplanation, NoPriorityLandscapesExplanation);
+    }
+
+    private const string SetBasedRegionSql = @"
+IF OBJECT_ID('tempdb..#ImportProject')  IS NOT NULL DROP TABLE #ImportProject;
+IF OBJECT_ID('tempdb..#ImportGeometry') IS NOT NULL DROP TABLE #ImportGeometry;
+
+CREATE TABLE #ImportProject (ProjectID int NOT NULL PRIMARY KEY, HasGeometry bit NOT NULL DEFAULT(0));
+INSERT INTO #ImportProject (ProjectID)
+SELECT DISTINCT CAST([value] AS int) FROM OPENJSON({0});
+
+CREATE TABLE #ImportGeometry (ProjectID int NOT NULL, Shape geometry NOT NULL);
+
+-- Detailed locations plus the simple point: exactly what the per-project version unions together.
+INSERT INTO #ImportGeometry (ProjectID, Shape)
+SELECT pl.ProjectID, pl.ProjectLocationGeometry.MakeValid()
+FROM dbo.ProjectLocation pl
+JOIN #ImportProject ip ON ip.ProjectID = pl.ProjectID
+WHERE pl.ProjectLocationGeometry IS NOT NULL;
+
+INSERT INTO #ImportGeometry (ProjectID, Shape)
+SELECT p.ProjectID, p.ProjectLocationPoint.MakeValid()
+FROM dbo.Project p
+JOIN #ImportProject ip ON ip.ProjectID = p.ProjectID
+WHERE p.ProjectLocationPoint IS NOT NULL;
+
+CREATE CLUSTERED INDEX IX_ImportGeometry_ProjectID ON #ImportGeometry (ProjectID);
+
+UPDATE ip SET HasGeometry = 1
+FROM #ImportProject ip
+WHERE EXISTS (SELECT 1 FROM #ImportGeometry g WHERE g.ProjectID = ip.ProjectID);
+
+DELETE pc  FROM dbo.ProjectCounty pc            JOIN #ImportProject ip ON ip.ProjectID = pc.ProjectID;
+DELETE pr  FROM dbo.ProjectRegion pr            JOIN #ImportProject ip ON ip.ProjectID = pr.ProjectID;
+DELETE ppl FROM dbo.ProjectPriorityLandscape ppl JOIN #ImportProject ip ON ip.ProjectID = ppl.ProjectID;
+
+INSERT INTO dbo.ProjectCounty (ProjectID, CountyID)
+SELECT DISTINCT g.ProjectID, c.CountyID
+FROM #ImportGeometry g CROSS JOIN dbo.County c
+WHERE c.CountyFeature.STIntersects(g.Shape) = 1;
+
+INSERT INTO dbo.ProjectRegion (ProjectID, DNRUplandRegionID)
+SELECT DISTINCT g.ProjectID, r.DNRUplandRegionID
+FROM #ImportGeometry g CROSS JOIN dbo.DNRUplandRegion r
+WHERE r.DNRUplandRegionLocation.STIntersects(g.Shape) = 1;
+
+INSERT INTO dbo.ProjectPriorityLandscape (ProjectID, PriorityLandscapeID)
+SELECT DISTINCT g.ProjectID, pl.PriorityLandscapeID
+FROM #ImportGeometry g CROSS JOIN dbo.PriorityLandscape pl
+WHERE pl.PriorityLandscapeLocation.STIntersects(g.Shape) = 1;
+
+-- Explanations. Two cases because the per-project version treats them differently: with geometry it
+-- ASSIGNS (the string when nothing intersected, NULL when something did); with no geometry at all it
+-- uses ??=, so it only fills an explanation that is already null.
+UPDATE p SET
+      NoCountiesExplanation           = CASE WHEN EXISTS (SELECT 1 FROM dbo.ProjectCounty x            WHERE x.ProjectID = p.ProjectID) THEN NULL ELSE {1} END
+    , NoRegionsExplanation            = CASE WHEN EXISTS (SELECT 1 FROM dbo.ProjectRegion x            WHERE x.ProjectID = p.ProjectID) THEN NULL ELSE {2} END
+    , NoPriorityLandscapesExplanation = CASE WHEN EXISTS (SELECT 1 FROM dbo.ProjectPriorityLandscape x WHERE x.ProjectID = p.ProjectID) THEN NULL ELSE {3} END
+FROM dbo.Project p JOIN #ImportProject ip ON ip.ProjectID = p.ProjectID
+WHERE ip.HasGeometry = 1;
+
+UPDATE p SET
+      NoCountiesExplanation           = ISNULL(p.NoCountiesExplanation,           {1})
+    , NoRegionsExplanation            = ISNULL(p.NoRegionsExplanation,            {2})
+    , NoPriorityLandscapesExplanation = ISNULL(p.NoPriorityLandscapesExplanation, {3})
+FROM dbo.Project p JOIN #ImportProject ip ON ip.ProjectID = p.ProjectID
+WHERE ip.HasGeometry = 0;
+
+DROP TABLE #ImportGeometry;
+DROP TABLE #ImportProject;
+";
+
+    /// <summary>
+    /// Maps normalized ProjectGisIdentifier → ProjectID for every project in a program that has one.
+    ///
+    /// Replaces a per-project <c>ProjectGisIdentifier.Trim().ToUpper() == @identifier</c> predicate,
+    /// which is non-sargable and has no supporting index, so each project scanned all of dbo.Project.
+    ///
+    /// Two intentional differences: normalization is <see cref="string.ToUpperInvariant"/> rather than
+    /// SQL's collation-aware <c>UPPER</c> (identical for the ASCII identifiers this column holds), and
+    /// where two projects in a program share an identifier the lowest ProjectID wins deterministically
+    /// instead of whichever row <c>FirstOrDefaultAsync</c> happened to return.
+    /// </summary>
+    private static async Task<Dictionary<string, int>> LoadExistingProjectIDsByIdentifierAsync(
+        WADNRDbContext dbContext, int programID)
+    {
+        var candidates = await dbContext.Projects
+            .AsNoTracking()
+            .Where(p => p.ProjectGisIdentifier != null && p.ProjectPrograms.Any(pp => pp.ProgramID == programID))
+            .OrderBy(p => p.ProjectID)
+            .Select(p => new { p.ProjectID, p.ProjectGisIdentifier })
+            .ToListAsync();
+
+        var projectIDByIdentifier = new Dictionary<string, int>(candidates.Count, StringComparer.Ordinal);
+        foreach (var candidate in candidates)
+        {
+            // First wins, and the ordering above makes "first" the lowest ProjectID.
+            projectIDByIdentifier.TryAdd(candidate.ProjectGisIdentifier!.Trim().ToUpperInvariant(), candidate.ProjectID);
+        }
+
+        return projectIDByIdentifier;
+    }
+
+    /// <summary>
+    /// Resolves the source org's default ProjectTypeID, with the same fallback-to-first-type the
+    /// per-project version used, paid once.
+    /// </summary>
+    private static async Task<int> ResolveDefaultProjectTypeIDAsync(WADNRDbContext dbContext, string projectTypeDefaultName)
+    {
+        var projectTypeID = await dbContext.ProjectTypes
+            .Where(pt => pt.ProjectTypeName == (projectTypeDefaultName ?? ""))
+            .Select(pt => pt.ProjectTypeID)
+            .FirstOrDefaultAsync();
+
+        return projectTypeID != 0
+            ? projectTypeID
+            : await dbContext.ProjectTypes.Select(pt => pt.ProjectTypeID).FirstAsync();
     }
 
     /// <summary>

--- a/WADNR.EFModels/Entities/GisBulkImport.StaticHelpers.cs
+++ b/WADNR.EFModels/Entities/GisBulkImport.StaticHelpers.cs
@@ -870,9 +870,12 @@ public static class GisBulkImports
     /// the per-project path ran NTS MakeValid and Union on every project's geometries and shipped the
     /// result as a query parameter.
     ///
-    /// Scoped by attempt rather than by an ID list, so this takes one int parameter instead of a
-    /// 3,042-element IN clause. That set is exactly the projects the loop touched; blocked projects are
-    /// correctly absent because they are skipped before anything is stamped.
+    /// Scoped by an explicit list of the projects this run touched, serialized as a JSON array and
+    /// expanded with OPENJSON — so it is still one parameter rather than a 3,042-element IN clause.
+    /// Deliberately NOT scoped by upload attempt: that would also sweep in projects an earlier run of
+    /// the same attempt touched but this one did not, recomputing regions that may since have been set
+    /// by hand (see the call site). Blocked projects are correctly absent from the list either way,
+    /// because they are skipped before anything is stamped.
     ///
     /// Equivalence with the per-project version: that one unions a project's geometries and intersects
     /// once; this intersects per geometry and takes DISTINCT. A union intersects R if and only if some

--- a/WADNR.EFModels/Entities/Project.StaticHelpers.cs
+++ b/WADNR.EFModels/Entities/Project.StaticHelpers.cs
@@ -66,6 +66,57 @@ public static class Projects
         return $"{prefix}{maxCounter + 1:D5}";
     }
 
+    /// <summary>
+    /// Hands out consecutive FHT project numbers from a block reserved with one query, for callers that
+    /// create many projects in a single pass.
+    ///
+    /// The GIS bulk import creates one project per distinct GIS identifier — 3,042 of them for a State
+    /// Lands GDB — and calling <see cref="GenerateFhtProjectNumberAsync"/> per project costs a round trip
+    /// each.
+    ///
+    /// Seeds itself by calling <see cref="GenerateFhtProjectNumberAsync"/> once and continuing from what
+    /// it returned, so "what the next FHT number is" and the FHT-{year}-{counter:D5} format stay defined
+    /// in exactly one place and cannot drift from the interactive create path. Parsing back the number
+    /// that method just formatted is deliberate: the alternative is refactoring a shared method to
+    /// expose its seed, for no measurable gain.
+    ///
+    /// Concurrency is no better and no worse than per-project generation: both read the current maximum
+    /// and then insert, so two simultaneous imports can collide. The unique index
+    /// AK_Project_FhtProjectNumber is what makes such a collision fail loudly rather than silently
+    /// duplicate a number.
+    /// </summary>
+    public sealed class FhtProjectNumberAllocator
+    {
+        private readonly string _prefix;
+        private int _nextCounter;
+
+        private FhtProjectNumberAllocator(string prefix, int nextCounter)
+        {
+            _prefix = prefix;
+            _nextCounter = nextCounter;
+        }
+
+        /// <summary>Reserves a block starting at the number the shared generator would hand out next.</summary>
+        public static async Task<FhtProjectNumberAllocator> CreateAsync(WADNRDbContext dbContext)
+        {
+            var firstNumber = await GenerateFhtProjectNumberAsync(dbContext);
+
+            // "FHT-2026-01159" -> prefix "FHT-2026-", counter 1159. The generator always produces that
+            // shape, so failing to parse means its format changed and throwing loudly is correct.
+            var lastDash = firstNumber.LastIndexOf('-');
+            if (lastDash < 0 || !int.TryParse(firstNumber[(lastDash + 1)..], out var firstCounter))
+            {
+                throw new InvalidOperationException(
+                    $"Could not read a counter out of generated FHT project number '{firstNumber}'.");
+            }
+
+            return new FhtProjectNumberAllocator(firstNumber[..(lastDash + 1)], firstCounter);
+        }
+
+        /// <summary>The next unused number, identical in shape to what the shared generator returns.</summary>
+        public string Next() => $"{_prefix}{_nextCounter++:D5}";
+    }
+
     public static async Task<List<ProjectCountyDetailGridRow>> ListAsCountyDetailGridRowAsync(WADNRDbContext dbContext, int countyID)
     {
         return await dbContext.Projects

--- a/WADNR.EFModels/Entities/ProjectCreateWorkflowSteps.cs
+++ b/WADNR.EFModels/Entities/ProjectCreateWorkflowSteps.cs
@@ -618,12 +618,7 @@ public static class ProjectCreateWorkflowSteps
     /// Auto-assigns geographic regions (priority landscapes, DNR upland regions, counties)
     /// based on project location intersections.
     /// </summary>
-    /// <param name="useNoAuditingSave">
-    /// When true, persists via SaveChangesWithNoAuditingAsync instead of SaveChangesAsync.
-    /// Used by system-driven paths (e.g. GIS bulk import and the nightly ArcGIS jobs) that
-    /// deliberately avoid writing audit fields.
-    /// </param>
-    internal static async Task AutoAssignGeographicRegionsAsync(WADNRDbContext dbContext, int projectID, bool useNoAuditingSave = false)
+    internal static async Task AutoAssignGeographicRegionsAsync(WADNRDbContext dbContext, int projectID)
     {
         var project = await dbContext.Projects
             .Include(p => p.ProjectLocations)
@@ -658,10 +653,7 @@ public static class ProjectCreateWorkflowSteps
             project.NoPriorityLandscapesExplanation ??= "Neither the simple location nor the detailed location on this project intersects with any Priority Landscape.";
             project.NoRegionsExplanation ??= "Neither the simple location nor the detailed location on this project intersects with any DNR Upland Region.";
             project.NoCountiesExplanation ??= "Neither the simple location nor the detailed location on this project intersects with any County.";
-            if (useNoAuditingSave)
-                await dbContext.SaveChangesWithNoAuditingAsync();
-            else
-                await dbContext.SaveChangesAsync();
+            await dbContext.SaveChangesAsync();
             return;
         }
 
@@ -731,10 +723,7 @@ public static class ProjectCreateWorkflowSteps
             ? "Neither the simple location nor the detailed location on this project intersects with any County."
             : null;
 
-        if (useNoAuditingSave)
-            await dbContext.SaveChangesWithNoAuditingAsync();
-        else
-            await dbContext.SaveChangesAsync();
+        await dbContext.SaveChangesAsync();
     }
 
     #endregion


### PR DESCRIPTION
Importing `2026_06_SL_Non_Comm.gdb` was timing out on QA. That file has a distinct `FMA_ID` on every one of its 3,042 features, so the import creates 3,042 projects — and it was written as a loop over them, paying every query, every round trip and one transaction commit that many times.

Three commits now: the C# rewrite ships in the assembly, the stored-procedure fix through the sqlproj, and a merge of `develop` that rebuilds the C# on top of WADNR-2287.

## Merged with develop (`94771755d`)

WADNR-2287 landed on `develop` after this PR opened and rewrote the same method. It restored ~12 behaviours the ProjectFirma-to-API rewrite had silently dropped — the ProjectStage and LeadImplementer crosswalks, GisExcludeIncludeColumns filtering, cross-program merge grouping, private landowner ProjectPerson creation, regional coordinator assignment, epoch-millisecond date parsing, the treatment-proc gate, and more — all into the per-project loop this PR deletes. Not a textual conflict.

Resolved by taking **develop's behaviour as the base and re-applying the set-based structure over it**, not the reverse. Every per-project decision now happens in a pure planning pass that touches no database and is recorded on a `ProjectPlan`; the transaction only writes. Decision *order* is preserved, because several of them interact — the missing-completion-date skip still runs before the ProjectID block list, so a project that is both undated and block-listed counts as skipped rather than blocked.

Three of develop's per-project queries had to become set-based rather than merely relocating:

| develop, per project | now |
|---|---|
| `ProjectGisIdentifier.Trim().ToUpper()` scan of `dbo.Project` | one preloaded index, scoped by `matchProgramIDs` so merge groupings still match a sibling program's project |
| `WidenDatesFromOtherProgramTreatmentsAsync` | one query for the whole update set, plus a pure `WidenDates` |
| `ApplyProjectLandownersAsync` (a query per project, a `SaveChanges` per new Person) | one query for existing rows, one batch insert for new People, one for roles and links |

**Two things a reviewer should look at in the resolution:**

1. **Region assignment now branches on the provider.** Develop added ~1,700 lines of InMemory tests calling `ImportProjectsAsync`, and the set-based region SQL throws on a non-relational provider. `AssignRegionsAsync` uses the batch on relational and falls back to the per-project `AutoAssignGeographicRegionsAsync` otherwise — the same shape `ClearStagedFeaturesAsync` already uses in this file. Consequence: this PR no longer touches `ProjectCreateWorkflowSteps.cs` at all, because the `useNoAuditingSave` parameter it previously removed is what the fallback needs. The alternative was migrating both new test files to SQL Server, which would have been a much larger change.

2. **One behaviour change falls out of the single transaction.** Develop only published a newly created Person to the shared index after that project's transaction committed, so one landowner name seen in two projects created one Person, while the same name seen twice within a single project created two. Every name now resolves through the same pending index, so it is always one Person. Reaching the old behaviour requires two distinct raw landowner values that collapse to the same name only after the 100-character truncation.

## Results

Measured end to end against `origin/develop` on the real 2026_06_SL_Non_Comm.gdb, 3,042 projects:

| | commands | wall | in-db | latency @2ms |
|---|---|---|---|---|
| `develop` (per-project) | 36,507 | 57.71s | 38.12s | 73.0s |
| this branch | **299** | **13.60s** | **8.51s** | **0.6s** |

**4.24x, with 99.2% of database round trips removed.**

> **These numbers predate the develop merge.** They were measured when `develop` still held the pre-WADNR-2287 loop, so the "develop" row describes a version that no longer exists, and the "this branch" row predates ~1,225 lines of restored behaviour landing in the same method. The structural claim is unchanged and is what the round-trip count reflects: nothing that reaches the database is per-project any more. The absolute figures want a re-run against a real GDB before anyone quotes them. The proc measurements below are unaffected — that commit is untouched by the merge.

The round-trip count is the number that travels. Locally a round trip is ~0.1ms so it barely registers; against Azure SQL at ~2ms it is roughly 73 seconds of the import's wall clock, and that is what the 299 removes.

Note that both sides of that table ran against the fixed stored procedure, so it isolates the C# change. The proc fix was measured separately in its own before/after: **58.96s → 14.29s**, with the proc itself going from ~40s to 1.97s.

## What changed

**`079afde30` — set-based import.** Every project is resolved in memory, then written in phases inside one transaction: all projects in a single `SaveChanges`, then their program and organization links, then one `SELECT` and two deletes for prior locations, then all new locations. (The merge commit re-applies this shape over develop's behaviour set and adds the landowner and date-widening batches described above.)

Region assignment was almost the entire cost. Per project it ran to 15,210 commands and 82.85s for this file, 56.7s of which was client-side — NTS `MakeValid` and `Union` over each project's geometries, then shipping the union as a query parameter. Set-based, the County / DNRUplandRegion / PriorityLandscape polygons are deserialized once instead of 18,252 times and the client work disappears entirely.

Three supporting lookups also leave the loop, each measured separately at 600 projects: the FHT number comes from a block reserved once, the existing-project lookup is a preloaded dictionary rather than a non-sargable `ProjectGisIdentifier.Trim().ToUpper()` scan of `dbo.Project`, and the default `ProjectType` is resolved once. A fourth candidate was measured and **dropped** — switching `GenerateFhtProjectNumberAsync` to SQL `MAX()` saved no commands and no time, so that method is untouched and the interactive create path is unaffected.

**`4c354f94f` — stored procedure.** `procImportTreatmentsFromGisUploadAttempt` was 77% of the import at ~40s, and it was a plan-quality problem rather than a missing index. Its `INSERT INTO #tempTreatments` filters `dbo.GisFeature` (2.46M rows) and joins `dbo.GisFeatureMetadataAttribute` (30M rows) nineteen times, all keyed on `@piGisUploadAttemptID`. The upload inserts those rows immediately before the import runs, so statistics still estimate ~1 matching row and the optimizer picks nested loops over both tables:

```
first execution against a fresh attempt   ~45s   160,566,442 logical reads
re-running the same proc afterwards        ~3s     2,459,154 logical reads
```

Production always hits the first case. Narrowing the attempt's features and metadata into temp tables first gives the optimizer real cardinality; the metadata copy is ~76,000 rows rather than 30 million. Every column is carried across so the existing predicates stay valid — the table names are the only change to the statements themselves.

Also in that commit: the cleanup `UPDATE` clearing `TemporaryTreatmentCacheID` had no `WHERE` clause, so it rewrote all 173,908 rows of `dbo.ProjectLocation` on every import to clear roughly 3,000 values, and would have kept growing with the table. Now 529ms → 42.6ms.

## Verification

Parity with the pre-merge implementation was proven by running `develop`'s implementation and this one against the same real data and diffing the resulting database state — **102,449 canonical values identical across all 3,042 projects**, under an order-sensitive bar with collections compared in insert order rather than sorted. Re-confirmed after code-review fixes, not just before them. That exercise predates the develop merge; parity with WADNR-2287's behaviour is carried by its own test suites, which all pass against the set-based implementation.

The three "does not intersect" explanation strings are reproduced verbatim and were diffed against `ProjectCreateWorkflowSteps` directly, because the snapshot compares them only as present/absent and would not have caught a wrong string.

`GisBulkImportArcGisIdTests` moves from the InMemory provider to real SQL Server. Region assignment is raw SQL now and InMemory has no relational provider — but those tests were already less faithful than they looked: the treatment proc needs a real connection too, and its failure was swallowed by the `catch` that turns proc errors into warnings, so all eight had been passing with treatments **silently skipped**. The two region tests are correspondingly stronger: instead of seeding a polygon that trivially overlaps, they assert the import agrees with an independent spatial query over the real Washington boundary data.

**Multi-project coverage (`7f6834e8a`).** The import writes in phases over the whole batch, but nearly every existing test imports a single project, so the batching itself was largely unexercised. Three tests close that, and each was verified by mutating the implementation and confirming it fails:

| test | mutation | result |
|---|---|---|
| `AssignsEachProjectItsOwnRegions_WhenImportingSeveralAtOnce` (SQL Server) — two projects at opposite ends of the state, counties and regions asserted **by ID** against an independent spatial query per geometry, guarded so the expected sets are non-empty and disjoint | drop the per-project scoping in the `ProjectCounty` insert | eastern project gets 2 counties instead of 1 |
| `ReplacesLocationsAndRegions_WhenSeveralProjectsAreReImported` (SQL Server) — import, re-stage, import again; asserts 0 created / 2 updated, still two locations, same county set | remove the batched location delete | `Violation of UNIQUE KEY constraint 'AK_ProjectLocation_ProjectID_ProgramID_ProjectLocationName'` |
| `CreatesAndUpdatesInTheSamePass_WithoutCrossingTheTwo` — one seeded project plus one new identifier; asserts the split, that an update is never renumbered, that the create draws past the highest number in use, that `CreateGisUploadAttemptID` lands only on the create, and that only the create gets a lead implementer row | seed `FhtProjectNumberAllocator` at 1 | collides with the existing number, as it would with `AK_Project_FhtProjectNumber` |

Full suite: **754/754**, plus the two `[Ignore]`d opt-in LOA AGOL tests.

## Behaviour changes worth reviewing

**The import is now all-or-nothing.** Previously each project committed independently, so a failure left the import half-applied with no record of where it stopped. The cost is a longer lock window, profiled with `sys.dm_tran_locks` sampled on a second connection during a real import:

| table | held | peak KEY X locks |
|---|---|---|
| `Project` | 11.37s | 6,084 |
| `ProjectLocation` | 9.56s | 6,084 |
| `ProjectProgram` | 7.76s | 9,126 |
| `ProjectCounty` | 6.13s | 9,192 |

The continuously-held window is ~8.7s; the remainder is the stored procedure afterwards, taking its own per-statement locks outside any explicit transaction. This was judged acceptable rather than chunked because locking stayed at row/page/key granularity — **no escalation to a table lock** — and because the database has `READ_COMMITTED_SNAPSHOT` on, so readers take no shared locks and never block. Only writers touching the same rows wait, which for a create pass is nobody.

**Three caveats on that judgement, all worth a reviewer's eye:**

1. **`READ_COMMITTED_SNAPSHOT` is load-bearing and nothing in this repo asserts it.** The local database is restored by `sqlpackage /a:Import` from a BacPac, and no script or publish profile sets it. It is on by default in Azure SQL Database and off by default on SQL Server. If an environment is ever provisioned without it, that 8.7s window becomes a stall for every reader and no test here would catch it. Worth confirming per environment: `SELECT name, is_read_committed_snapshot_on FROM sys.databases WHERE name = 'WADNRDB';`
2. **Escalation headroom is finite.** Escalation fires at roughly 5,000 locks in a single statement, and the set-based `INSERT` into `ProjectCounty` is plausibly around 4,500 at this file size. A substantially larger GDB could cross it.
3. **The lock profile predates the develop merge.** The transaction now also covers the landowner batch, which for a source org with the Landowner column mapped adds `Person`, `PersonRole` and `ProjectPerson` to the tables held. The State Lands GDB that produced the table above does not map that column, so it is unchanged there; DNR LOA NE would need its own profile.

**Deployment:** the commits land through different paths — the C# in the assembly, the proc via the sqlproj. `dbo.ProjectLocation` has a spatial index, and spatial index DML requires `QUOTED_IDENTIFIER ON`; applying the proc through sqlcmd **without `-I`** recompiles it with `uses_quoted_identifier = 0`, after which every DELETE and UPDATE against ProjectLocation inside it fails at *runtime* with Msg 1934 — not at deploy time. SSDT deploys it correctly.

WADNR-2287's release script (`0009 - ... Correct project types on GIS bulk imported projects.sql`) arrives through the merge and is unmodified by it.

## Not addressed

`procImportTreatmentsFromGisUploadAttempt` names the locations it creates from the `ProjectLocationID` it has just assigned, so re-importing the same GDB produces differently-named treatment-area locations every time — the same defect WADNR-2150 fixed on the C# side. Out of scope here; worth its own card.

`ImportProjects_AssignsCoordinatorOnlyOnce_WhenRunTwice`, which arrives from develop, passes vacuously: a successful import clears its own staged features, so its second `ImportProjectsAsync` call finds nothing and is a no-op. Coordinator idempotency is therefore not actually covered. Left as found rather than fixed here — the new re-import test re-stages between runs specifically to avoid that trap. Also worth its own card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
