### PR TITLE
Make HTTP failures say what actually failed, and scope the interceptor to our API

### DIFF
--- a/WADNR.Web/e2e-tests/error-handling/http-error-interceptor.spec.ts
+++ b/WADNR.Web/e2e-tests/error-handling/http-error-interceptor.spec.ts
@@ -1,0 +1,170 @@
+import { test, expect, Page } from "@playwright/test";
+
+/**
+ * Exercises HttpErrorInterceptor at the network boundary, which is where it lives.
+ *
+ * Raw @playwright/test rather than the shared base fixture: every test here deliberately forces an API
+ * failure, and that fixture's API error monitor fails a test when it sees one. The same reasoning as
+ * not-found-pages.spec.ts.
+ *
+ * Failures are produced with page.route() rather than by finding a real broken endpoint, so these need
+ * no particular server state — only the app and API running at the configured baseURL.
+ */
+
+/** Console output produced after this is called. Attach before navigating. */
+function collectConsoleErrors(page: Page): string[] {
+    const lines: string[] = [];
+    page.on("console", (message) => {
+        if (message.type() === "error") {
+            lines.push(message.text());
+        }
+    });
+    return lines;
+}
+
+test.describe("HttpErrorInterceptor", () => {
+    test("a transport failure names the request and does not log [object ProgressEvent]", async ({ page }) => {
+        // The reported bug: "Backend returned code 0, body was: [object ProgressEvent]" — no URL, no
+        // method, and nothing to act on. Status 0 means no HTTP response arrived at all.
+        const consoleErrors = collectConsoleErrors(page);
+        await page.route("**/api/**", (route) => route.abort("failed"));
+
+        await page.goto("/projects");
+
+        await expect
+            .poll(() => consoleErrors.join("\n"), { timeout: 15000 })
+            .toMatch(/never reached the server \(status 0\)/);
+
+        const logged = consoleErrors.join("\n");
+        expect(logged, "the failing request must be identifiable").toMatch(/HTTP GET \S*\/api\//);
+        expect(logged, "the transport event type is the diagnostic bit").toMatch(/Transport event type="/);
+        expect(logged).not.toContain("[object ProgressEvent]");
+        expect(logged).not.toContain("Backend returned code 0");
+    });
+
+    test("an empty error body still logs something actionable", async ({ page }) => {
+        // A 500 with no body is common, and JSON.stringify(null) renders the string "null" — no more use
+        // in a log than the "[object Object]" this replaced. Falls back to Angular's own message, which
+        // at least carries the URL and status.
+        const consoleErrors = collectConsoleErrors(page);
+        await page.route("**/api/**", (route) => route.fulfill({ status: 500, body: "" }));
+
+        await page.goto("/projects");
+
+        await expect
+            .poll(() => consoleErrors.filter((line) => line.startsWith("HTTP ")).join("\n"), { timeout: 15000 })
+            .toMatch(/failed with 500: (no|empty) response body\. Angular reported: /);
+
+        const logged = consoleErrors.filter((line) => line.startsWith("HTTP ")).join("\n");
+        expect(logged).not.toMatch(/failed with 500: null\b/);
+        expect(logged).not.toMatch(/failed with 500: \{\}/);
+    });
+
+    test("400 validation errors surface once per field, not once per request", async ({ page }) => {
+        // ValidationProblemDetails, as produced by [ApiController] model validation. Its `title` is only
+        // ever "One or more validation errors occurred."; the per-field entries say what to fix.
+        await page.route("**/api/**", (route) =>
+            route.fulfill({
+                status: 400,
+                contentType: "application/json",
+                body: JSON.stringify({
+                    title: "One or more validation errors occurred.",
+                    errors: {
+                        ProjectName: ["Project Name is required."],
+                        ProjectStage: ["Project Stage is required."],
+                    },
+                }),
+            })
+        );
+
+        await page.goto("/projects");
+
+        // Every field gets its own alert. These are strict-mode locators with no .first(), so a second
+        // copy of either message fails the assertion on its own.
+        await expect(page.getByText("Project Name is required.")).toBeVisible({ timeout: 15000 });
+        await expect(page.getByText("Project Stage is required.")).toBeVisible();
+
+        // One alert per field however many requests the page fired — this page fires three, and each
+        // is rejected identically. alert-display renders only the first three alerts, so without a
+        // per-message uniqueCode the repeats of the first field crowd the second one out of view.
+        await page.waitForLoadState("networkidle");
+        await expect(page.getByText("Project Name is required.")).toHaveCount(1);
+        await expect(page.getByText("Project Stage is required.")).toHaveCount(1);
+    });
+
+    test("400 with a plain string body surfaces that string", async ({ page }) => {
+        // What BadRequest("...") produces.
+        await page.route("**/api/**", (route) =>
+            route.fulfill({ status: 400, contentType: "text/plain", body: "That file type is not accepted." })
+        );
+
+        await page.goto("/projects");
+
+        await expect(page.getByText("That file type is not accepted.").first()).toBeVisible({ timeout: 15000 });
+    });
+
+    test("403 shows the server message and does not navigate to a dead route", async ({ page }) => {
+        // This used to redirect to /subscription-insufficient — a ProjectFirma fork artifact with no
+        // route in this app, so it fell through to the "**" handler and landed on /not-found.
+        await page.route("**/api/**", (route) =>
+            route.fulfill({ status: 403, contentType: "text/plain", body: "You do not have permission to view this." })
+        );
+
+        await page.goto("/projects");
+
+        await expect(page.getByText("You do not have permission to view this.").first()).toBeVisible({ timeout: 15000 });
+        expect(page.url()).not.toContain("/subscription-insufficient");
+        expect(page.url()).not.toContain("/not-found");
+    });
+
+    test("a 404 from the external geocoder does not pull the user to not-found", async ({ page }) => {
+        // The isOurApi gate. The app also talks to WAMAS, Nominatim and GeoServer; a miss from one of
+        // those belongs to whichever component asked for it, not to the router.
+        //
+        // The geocoder is driven deliberately rather than relying on page load. An earlier version of
+        // this test intercepted GeoServer on /projects/map and asserted no navigation — but that page
+        // issues zero GeoServer requests through HttpClient (Leaflet fetches WMS tiles as <img>, and the
+        // WFS call only fires on a map click elsewhere), so it passed without exercising the gate at all
+        // and would have passed with isOurApi deleted. Hence the routeHit assertion below.
+        let routeHit = false;
+        await page.route(/wamas|nominatim|geocod/i, (route) => {
+            routeHit = true;
+            // Access-Control-Allow-Origin is required, not decoration. WAMAS is cross-origin; without it
+            // the browser rejects the fulfilled response and Angular reports status 0, which never
+            // reaches the 404 branch — the test would then pass with isOurApi deleted.
+            return route.fulfill({
+                status: 404,
+                contentType: "text/plain",
+                headers: { "Access-Control-Allow-Origin": "*" },
+                body: "Address not found",
+            });
+        });
+
+        // /find-your-forester rather than /projects/map: it is public, and it renders <map-search>
+        // unconditionally rather than behind *ngIf="mapIsReady". Locators are scoped to that component
+        // because getByLabel(/search/) also matches the main nav's search button.
+        await page.goto("/find-your-forester");
+        const mapSearch = page.locator("map-search").first();
+        await mapSearch.getByRole("textbox").first().fill("1111 Washington St SE, Olympia WA");
+        await mapSearch.getByRole("button", { name: /zoom|search/i }).first().click();
+
+        await expect
+            .poll(() => routeHit, { timeout: 15000 })
+            .toBe(true);
+
+        // The gate: an external 404 must not navigate.
+        await page.waitForTimeout(1000);
+        expect(page.url()).not.toContain("/not-found");
+    });
+
+    test("a 404 from our own API still redirects to not-found", async ({ page }) => {
+        // The other half of the gate: narrowing which failures navigate must not stop the ones that should.
+        await page.route("**/api/projects**", (route) =>
+            route.fulfill({ status: 404, contentType: "text/plain", body: "Project does not exist!" })
+        );
+
+        await page.goto("/projects/999999");
+
+        await expect.poll(() => page.url(), { timeout: 15000 }).toContain("/not-found");
+    });
+});

--- a/WADNR.Web/e2e-tests/error-handling/http-error-interceptor.spec.ts
+++ b/WADNR.Web/e2e-tests/error-handling/http-error-interceptor.spec.ts
@@ -103,6 +103,48 @@ test.describe("HttpErrorInterceptor", () => {
         await expect(page.getByText("That file type is not accepted.").first()).toBeVisible({ timeout: 15000 });
     });
 
+    test("two different 400 messages both surface", async ({ page }) => {
+        // The other half of per-message dedupe. A flat "Http400" code would collapse these two into
+        // one alert, because AlertService drops any alert whose code it has already seen — so the
+        // second endpoint's rejection would silently never reach the user.
+        await page.route("**/api/projects**", (route) =>
+            route.fulfill({ status: 400, contentType: "text/plain", body: "That file type is not accepted." })
+        );
+        await page.route("**/api/relationship-types**", (route) =>
+            route.fulfill({ status: 400, contentType: "text/plain", body: "Relationship type is unknown." })
+        );
+
+        await page.goto("/projects");
+
+        await expect(page.getByText("That file type is not accepted.")).toBeVisible({ timeout: 15000 });
+        await expect(page.getByText("Relationship type is unknown.")).toBeVisible();
+    });
+
+    test("markup in a server message renders as text, not as elements", async ({ page }) => {
+        // alert-display binds [innerHTML]. Angular's sanitizer drops scripts and event handlers, but
+        // it renders <a> and <img> quite happily — and 400s routinely quote user-supplied values back,
+        // so without escaping one user could put a link or a tracking pixel in another user's alert.
+        await page.route("**/api/**", (route) =>
+            route.fulfill({
+                status: 400,
+                contentType: "application/json",
+                body: JSON.stringify({
+                    errors: { ProjectName: ['Name <a href="https://example.com/evil">click here</a> is taken.'] },
+                }),
+            })
+        );
+
+        await page.goto("/projects");
+
+        const alerts = page.locator("alert");
+        await expect(alerts.first()).toBeVisible({ timeout: 15000 });
+
+        // The markup survives as visible text...
+        await expect(alerts.first()).toContainText('<a href="https://example.com/evil">');
+        // ...and produced no actual element.
+        await expect(alerts.locator('a[href="https://example.com/evil"]')).toHaveCount(0);
+    });
+
     test("403 shows the server message and does not navigate to a dead route", async ({ page }) => {
         // This used to redirect to /subscription-insufficient — a ProjectFirma fork artifact with no
         // route in this app, so it fell through to the "**" handler and landed on /not-found.
@@ -152,9 +194,11 @@ test.describe("HttpErrorInterceptor", () => {
             .poll(() => routeHit, { timeout: 15000 })
             .toBe(true);
 
-        // The gate: an external 404 must not navigate.
-        await page.waitForTimeout(1000);
-        expect(page.url()).not.toContain("/not-found");
+        // The gate: an external 404 must not navigate. Waiting *for* the navigation and requiring it
+        // to time out, rather than sleeping a fixed interval and reading the URL after — a fixed sleep
+        // passes on any run slow enough that the redirect simply hadn't landed yet, which is the run
+        // most likely to be hiding a regression.
+        await expect(page.waitForURL(/\/not-found/, { timeout: 5000 })).rejects.toThrow();
     });
 
     test("a 404 from our own API still redirects to not-found", async ({ page }) => {

--- a/WADNR.Web/src/app/shared/interceptors/httpErrorInterceptor.ts
+++ b/WADNR.Web/src/app/shared/interceptors/httpErrorInterceptor.ts
@@ -1,71 +1,296 @@
-import { Injectable } from "@angular/core";
-import { HttpInterceptor, HttpRequest, HttpErrorResponse, HttpHandler, HttpEvent, HttpResponse } from "@angular/common/http";
+import { Injectable, Injector } from "@angular/core";
+import { HttpInterceptor, HttpRequest, HttpErrorResponse, HttpHandler, HttpEvent } from "@angular/common/http";
 
-import { Observable, EMPTY, throwError, of } from "rxjs";
+import { Observable, throwError } from "rxjs";
 import { catchError } from "rxjs/operators";
 import { Router } from "@angular/router";
 import { AlertService } from "../services/alert.service";
 import { AlertContext } from "../models/enums/alert-context.enum";
 import { Alert } from "../models/alert";
+import { AuthenticationService } from "src/app/services/authentication.service";
+import { environment } from "src/environments/environment";
 
+/**
+ * The single owner of "this HTTP status means go somewhere else / sign out".
+ *
+ * Only failures from our own API are acted on here. The app also talks to GeoServer (WFS), Nominatim
+ * and WAMAS; a 404 from a geocoder must not yank the user to /not-found, so those pass straight
+ * through to whichever component asked for them.
+ */
 @Injectable()
 export class HttpErrorInterceptor implements HttpInterceptor {
-    constructor(private router: Router, private alertService: AlertService) {}
+    /**
+     * Absolute form of the API base. mainAppApiUrl is relative in dev ("/api") and absolute in the
+     * deployed environments, while request URLs resolve to absolute — normalize both before comparing.
+     */
+    private static readonly apiBaseUrl = new URL(environment.mainAppApiUrl, window.location.origin).href.replace(/\/+$/, "");
+
+    // AuthenticationService is resolved lazily rather than injected: it depends on the generated
+    // UserClaimsService, which depends on HttpClient, which builds this interceptor — taking it as a
+    // constructor dependency risks a DI cycle. By the time a request can fail it is always constructed.
+    constructor(private router: Router, private alertService: AlertService, private injector: Injector) {}
+
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         return next.handle(request).pipe(
             catchError((error: HttpErrorResponse) => {
-                if (error.error instanceof Error) {
-                    // A client-side or network error occurred. Handle it accordingly.
-                    console.error("An error occurred:", error.error.message);
-                } else {
-                    // The backend returned an unsuccessful response code.
-                    // The response body may contain clues as to what went wrong,
-                    console.error(`Backend returned code ${error.status}, body was: ${error.error}`);
+                console.error(this.describeFailure(request, error));
 
-                    if (error instanceof HttpErrorResponse) {
-                        if (error.status == 401) {
-                            this.router.navigateByUrl("/unauthenticated", { replaceUrl: false }).then((x) => {
-                                if (typeof error.error === "string") {
-                                    this.alertService.pushAlert(new Alert(error.error, AlertContext.Danger));
-                                }
-                            });
-                        }
-                        if (error.status == 403) {
-                            this.router.navigateByUrl("/subscription-insufficient", { replaceUrl: false }).then((x) => {
-                                if (typeof error.error === "string") {
-                                    this.alertService.pushAlert(new Alert(error.error, AlertContext.Danger));
-                                }
-                            });
-                        }
-                        if (error.status == 404) {
-                            // Custom pages handle their own 404 UX (see CustomPageComponent)
-                            if (request.url.includes("/custom-pages/")) {
-                                return throwError(error);
-                            }
-
-                            if (typeof error.error === "string" && error.error.includes("User with GUID ")) {
-                                // we want the login-callback to create the user to trigger so we just let it pass through and have authentication-service handle it
-                                return throwError(error);
-                            } else {
-                                this.router.navigateByUrl("/not-found", { replaceUrl: false }).then((x) => {
-                                    if (typeof error.error === "string") {
-                                        this.alertService.pushAlert(new Alert(error.error, AlertContext.Danger));
-                                    }
-                                });
-                            }
-                        }
+                if (this.isOurApi(request)) {
+                    if (error.status === 400) {
+                        this.handleBadRequest(error);
+                    } else if (error.status === 401) {
+                        this.handleUnauthenticated(error);
+                    } else if (error.status === 403) {
+                        this.handleForbidden(error);
+                    } else if (error.status === 404) {
+                        this.handleNotFound(request, error);
                     }
                 }
 
-                // If you want to return a new response:
-                //return of(new HttpResponse({body: [{name: "Default value..."}]}));
-
-                // If you want to return nothing:
-                //return EMPTY;
-
-                // Otherwise pass it on to the upper level and let them take care of it:
-                return throwError(error);
+                // Pass it on to the upper level and let them take care of it.
+                return throwError(() => error);
             })
         );
+    }
+
+    /**
+     * A 400 carries the reason the request was rejected, and the shape depends on who rejected it.
+     * Without this the user saw a generic failure while the actual reason sat unread in the body.
+     * Modelled on the equivalent handling in Qanat and Neptune, minus their RowErrors branch — that
+     * shape is specific to their bulk-import endpoints and this API never returns it.
+     */
+    private handleBadRequest(error: HttpErrorResponse): void {
+        const body = error?.error;
+
+        // BadRequest() with no body, or a download endpoint's blob — nothing readable to show.
+        if (!body || body instanceof Blob) {
+            return;
+        }
+
+        if (typeof body === "string") {
+            this.pushServerMessage(error, "Http400");
+            return;
+        }
+
+        // ValidationProblemDetails from [ApiController] model validation: { errors: { Field: [msg] } }.
+        // Checked before the generic message extraction because its `title` is only ever the useless
+        // "One or more validation errors occurred." while the per-field entries say what to fix.
+        const validationErrors = body.errors;
+        if (validationErrors && typeof validationErrors === "object") {
+            this.pushFieldMessages(validationErrors);
+            return;
+        }
+
+        // ProblemDetails, or an object carrying a single message.
+        if (this.pushServerMessage(error, "Http400")) {
+            return;
+        }
+
+        // Otherwise assume a dictionary of messages keyed by field.
+        this.pushFieldMessages(body);
+    }
+
+    /**
+     * One alert per field of a validation dictionary.
+     *
+     * The unique code is per *message*, not per status. A page that fires several requests gets the
+     * same rejection back several times over, and with no code AlertService stacks every copy —
+     * alert-display renders only the first three, so three duplicates of one message push everything
+     * else out of view. Keying on the message collapses those repeats while still letting a genuine
+     * multi-field failure show one alert per field, which a flat "Http400" would suppress.
+     */
+    private pushFieldMessages(container: Record<string, unknown>): void {
+        for (const field of Object.keys(container)) {
+            const message = this.formatMessages(container[field]);
+            if (message) {
+                this.alertService.pushAlert(new Alert(message, AlertContext.Danger, true, `Http400:${message}`));
+            }
+        }
+    }
+
+    /** Validation entries arrive as either a single message or an array of them. */
+    private formatMessages(value: unknown): string {
+        if (Array.isArray(value)) {
+            return value.map((entry) => String(entry)).filter((entry) => entry.length > 0).join("<br/>");
+        }
+        return typeof value === "string" ? value.trim() : "";
+    }
+
+    /**
+     * A 401 means the cached session is no longer usable. This used to navigate to /unauthenticated —
+     * a route this app never defined, so it fell through to the "**" custom-page handler and the user
+     * landed on /not-found with the dead session still cached, reproducing the 401 on every reload.
+     * Now the unusable session is discarded and a fresh sign-in starts.
+     */
+    private handleUnauthenticated(error: HttpErrorResponse): void {
+        const authenticationService = this.injector.get(AuthenticationService, null);
+
+        // An anonymous user hitting a protected endpoint (e.g. a stray call from a public page, or an
+        // API call that races Auth0 finishing its token exchange) must not be kicked into a sign-out
+        // redirect — that loops. Say what happened and stay on the page.
+        if (!authenticationService?.isAuthenticated()) {
+            if (!this.pushServerMessage(error, "Http401")) {
+                this.alertService.pushAlert(new Alert("You must be signed in to view this. Please sign in and try again.", AlertContext.Danger, true, "Http401"));
+            }
+            return;
+        }
+
+        // No alert here: forcedLogout() triggers a full-page Auth0 redirect, which wipes any alert
+        // before it could be read.
+        authenticationService.forcedLogout();
+    }
+
+    /**
+     * Surfaces the server's 403 message and lets the originating component handle the error (rethrown
+     * by the caller) so it stays mounted to report it.
+     *
+     * This used to force navigation to /subscription-insufficient — a ProjectFirma fork artifact (this
+     * app has no subscription concept, and the route doesn't exist, so it fell through to the "**"
+     * custom-page handler and ended on /not-found). Navigating also tore down whatever modal made the
+     * request before it could show the failure.
+     */
+    private handleForbidden(error: HttpErrorResponse): void {
+        if (!this.pushServerMessage(error, "Http403")) {
+            this.alertService.pushNotFoundUnauthorizedAlert();
+        }
+    }
+
+    private handleNotFound(request: HttpRequest<any>, error: HttpErrorResponse): void {
+        // Custom pages own their own 404 UX: the "**" route renders CustomPageComponent for every
+        // unknown URL and it redirects to /not-found itself. Navigating here too races that redirect.
+        if (request.url.includes("/custom-pages/")) {
+            return;
+        }
+
+        // A missing user record must reach AuthenticationService / the login callback so it can create
+        // the user. (The message this matched on used to be "User with GUID ", which UserClaimsController
+        // has never returned — it says "User with GlobalID ... does not exist!" — so the check was dead
+        // and these 404s were being redirected. Match on the endpoint instead of the message text.)
+        if (request.url.includes("/user-claims")) {
+            return;
+        }
+
+        // Blob responses (Excel/PDF downloads) have an unreadable body and belong to the caller that
+        // started the download — reading .includes() off a Blob also throws.
+        if (error.error instanceof Blob || request.responseType === "blob") {
+            return;
+        }
+
+        this.router.navigateByUrl("/not-found", { replaceUrl: false }).then(() => {
+            // Pushed after navigation settles: the outgoing page's alert-display clears alerts on destroy.
+            this.pushServerMessage(error);
+        });
+    }
+
+    /**
+     * True when the request went to our API rather than GeoServer, Nominatim, WAMAS or a static asset.
+     */
+    private isOurApi(request: HttpRequest<any>): boolean {
+        const base = HttpErrorInterceptor.apiBaseUrl;
+        let href: string;
+        try {
+            href = new URL(request.url, window.location.origin).href;
+        } catch {
+            return false;
+        }
+        // Segment boundary check so a sibling path like "/apiary" can't match a base of "/api".
+        return href === base || href.startsWith(`${base}/`) || href.startsWith(`${base}?`);
+    }
+
+    /** Surfaces the server's own message when it sent one. Returns whether an alert was pushed. */
+    private pushServerMessage(error: HttpErrorResponse, uniqueCode: string = ""): boolean {
+        const message = this.extractServerMessage(error);
+        if (!message) {
+            return false;
+        }
+        this.alertService.pushAlert(new Alert(message, AlertContext.Danger, true, uniqueCode));
+        return true;
+    }
+
+    /**
+     * Pulls a displayable message out of the response body. The API returns plain strings from
+     * NotFound()/BadRequest() and ProblemDetails objects from the framework's own failures.
+     */
+    private extractServerMessage(error: HttpErrorResponse): string | null {
+        const body = error?.error;
+        if (typeof body === "string") {
+            return body.trim() || null;
+        }
+        if (body && typeof body === "object" && !(body instanceof Blob)) {
+            const candidate = body.Message ?? body.message ?? body.detail ?? body.title;
+            if (typeof candidate === "string") {
+                return candidate.trim() || null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * One console line that says which request failed and why.
+     *
+     * The old message was `Backend returned code 0, body was: [object ProgressEvent]` — no URL, no
+     * method, and a body rendered by string coercion. Status 0 in particular does not mean the backend
+     * returned anything: it means no HTTP response arrived at all, and Angular hands back a
+     * ProgressEvent rather than a body. Neither the endpoint nor the reason was recoverable from that.
+     */
+    private describeFailure(request: HttpRequest<any>, error: HttpErrorResponse): string {
+        const where = `${request.method} ${request.urlWithParams}`;
+
+        if (error.status === 0) {
+            return (
+                `HTTP ${where} never reached the server (status 0) — network failure, CORS rejection, ` +
+                `a blocked request, or one cancelled in flight by navigation. ${this.describeTransport(error)}`
+            );
+        }
+
+        return `HTTP ${where} failed with ${error.status}: ${this.describeErrorBody(error)}`;
+    }
+
+    /**
+     * What little a failed transport carries. A ProgressEvent has no enumerable own properties, so
+     * JSON.stringify renders it as "{}" — its `type` ("error", "timeout", "abort") is the useful part,
+     * and it distinguishes a genuine connectivity failure from a request the user cancelled by
+     * navigating away.
+     */
+    private describeTransport(error: HttpErrorResponse): string {
+        const body = error?.error;
+
+        if (typeof ProgressEvent !== "undefined" && body instanceof ProgressEvent) {
+            return `Transport event type="${body.type}". Angular reported: ${error.message}`;
+        }
+        if (body instanceof Error) {
+            return `${body.name}: ${body.message}`;
+        }
+        return error.message || "No further detail available.";
+    }
+
+    /** Loggable rendering of the response body, including object and Blob bodies. */
+    private describeErrorBody(error: HttpErrorResponse): string {
+        const body = error?.error;
+
+        // An empty body is common on 500s. "null" or "{}" in the log is no more use than the
+        // "[object Object]" this replaced, so say there was no body and fall back to Angular's message,
+        // which at least carries the URL and status.
+        if (body === null || body === undefined) {
+            return `no response body. Angular reported: ${error.message || "(nothing further)"}`;
+        }
+        if (body instanceof Blob) {
+            return `[Blob ${body.type || "unknown type"}, ${body.size} bytes]`;
+        }
+        if (typeof body === "string") {
+            return body.trim() || `empty response body. Angular reported: ${error.message || "(nothing further)"}`;
+        }
+        if (body instanceof Error) {
+            return `${body.name}: ${body.message}`;
+        }
+        try {
+            const rendered = JSON.stringify(body);
+            if (rendered && rendered !== "{}" && rendered !== "null") {
+                return rendered;
+            }
+            return `unreadable response body. Angular reported: ${error.message || "(nothing further)"}`;
+        } catch {
+            return `unserializable response body (${String(body)}). Angular reported: ${error.message || "(nothing further)"}`;
+        }
     }
 }

--- a/WADNR.Web/src/app/shared/interceptors/httpErrorInterceptor.ts
+++ b/WADNR.Web/src/app/shared/interceptors/httpErrorInterceptor.ts
@@ -60,7 +60,7 @@ export class HttpErrorInterceptor implements HttpInterceptor {
      * shape is specific to their bulk-import endpoints and this API never returns it.
      */
     private handleBadRequest(error: HttpErrorResponse): void {
-        const body = error?.error;
+        const body: unknown = error?.error;
 
         // BadRequest() with no body, or a download endpoint's blob — nothing readable to show.
         if (!body || body instanceof Blob) {
@@ -68,52 +68,95 @@ export class HttpErrorInterceptor implements HttpInterceptor {
         }
 
         if (typeof body === "string") {
-            this.pushServerMessage(error, "Http400");
+            this.pushBadRequestMessage(this.extractServerMessage(error));
             return;
         }
+
+        const fields = body as Record<string, unknown>;
 
         // ValidationProblemDetails from [ApiController] model validation: { errors: { Field: [msg] } }.
         // Checked before the generic message extraction because its `title` is only ever the useless
         // "One or more validation errors occurred." while the per-field entries say what to fix.
-        const validationErrors = body.errors;
+        const validationErrors = fields["errors"];
         if (validationErrors && typeof validationErrors === "object") {
-            this.pushFieldMessages(validationErrors);
+            this.pushFieldMessages(validationErrors as Record<string, unknown>);
             return;
         }
 
         // ProblemDetails, or an object carrying a single message.
-        if (this.pushServerMessage(error, "Http400")) {
+        if (this.pushBadRequestMessage(this.extractServerMessage(error))) {
             return;
         }
 
         // Otherwise assume a dictionary of messages keyed by field.
-        this.pushFieldMessages(body);
+        this.pushFieldMessages(fields);
     }
 
     /**
      * One alert per field of a validation dictionary.
+     */
+    private pushFieldMessages(container: Record<string, unknown>): void {
+        for (const field of Object.keys(container)) {
+            // Already escaped by formatMessages, which owns the <br/> joining.
+            this.pushBadRequestAlert(this.formatMessages(container[field]));
+        }
+    }
+
+    /** Escapes and pushes a single 400 message. Returns whether there was one to push. */
+    private pushBadRequestMessage(message: string | null): boolean {
+        if (!message) {
+            return false;
+        }
+        this.pushBadRequestAlert(HttpErrorInterceptor.escapeHtml(message));
+        return true;
+    }
+
+    /**
+     * Pushes 400 content that is already escaped and display-ready.
      *
      * The unique code is per *message*, not per status. A page that fires several requests gets the
      * same rejection back several times over, and with no code AlertService stacks every copy —
      * alert-display renders only the first three, so three duplicates of one message push everything
-     * else out of view. Keying on the message collapses those repeats while still letting a genuine
-     * multi-field failure show one alert per field, which a flat "Http400" would suppress.
+     * else out of view. Keying on the message collapses those repeats while still letting genuinely
+     * different rejections each be seen, which a flat "Http400" would suppress. 401/403 stay flat by
+     * contrast: those say "you are not signed in" / "you may not do this", and one alert is the
+     * whole message however many requests hit it.
      */
-    private pushFieldMessages(container: Record<string, unknown>): void {
-        for (const field of Object.keys(container)) {
-            const message = this.formatMessages(container[field]);
-            if (message) {
-                this.alertService.pushAlert(new Alert(message, AlertContext.Danger, true, `Http400:${message}`));
-            }
+    private pushBadRequestAlert(safeMessage: string): void {
+        if (!safeMessage) {
+            return;
         }
+        this.alertService.pushAlert(new Alert(safeMessage, AlertContext.Danger, true, `Http400:${safeMessage}`));
     }
 
     /** Validation entries arrive as either a single message or an array of them. */
     private formatMessages(value: unknown): string {
         if (Array.isArray(value)) {
-            return value.map((entry) => String(entry)).filter((entry) => entry.length > 0).join("<br/>");
+            return value
+                .map((entry) => HttpErrorInterceptor.escapeHtml(String(entry).trim()))
+                .filter((entry) => entry.length > 0)
+                .join("<br/>");
         }
-        return typeof value === "string" ? value.trim() : "";
+        return typeof value === "string" ? HttpErrorInterceptor.escapeHtml(value.trim()) : "";
+    }
+
+    /**
+     * Escapes text on its way into an alert.
+     *
+     * alert-display renders alert.message through [innerHTML]. Angular's DomSanitizer strips scripts,
+     * event handlers and javascript: URLs, so this was never an XSS hole — but it happily renders
+     * benign-looking markup like <a href> and <img src>, and 400 messages routinely quote user-supplied
+     * values back ("Project name 'X' already exists"), which is enough for one user to put a link or a
+     * tracking pixel in another's alert. Escaping here means the only markup that survives is the
+     * <br/> that formatMessages puts in deliberately, after its parts are already escaped.
+     */
+    private static escapeHtml(value: string): string {
+        return value
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
     }
 
     /**
@@ -203,7 +246,7 @@ export class HttpErrorInterceptor implements HttpInterceptor {
         if (!message) {
             return false;
         }
-        this.alertService.pushAlert(new Alert(message, AlertContext.Danger, true, uniqueCode));
+        this.alertService.pushAlert(new Alert(HttpErrorInterceptor.escapeHtml(message), AlertContext.Danger, true, uniqueCode));
         return true;
     }
 


### PR DESCRIPTION
A failure in the app recently logged this and nothing else:

```
Backend returned code 0, body was: [object ProgressEvent]
```

No URL, no method, and a body rendered by string coercion. Status 0 does not mean the backend returned anything — it means no HTTP response arrived at all, and Angular hands back a `ProgressEvent` rather than a body. Neither the endpoint nor the reason was recoverable from that line.

Three commits: the interceptor rewrite, the Playwright specs, then the review fixes.

## What a failure logs now

Real output, captured from the specs rather than written from memory:

| shape | logged |
|---|---|
| transport | `HTTP GET /api/custom-pages/navigation-section/1 never reached the server (status 0) — network failure, CORS rejection, a blocked request, or one cancelled in flight by navigation. Transport event type="error". Angular reported: …` |
| 500, object body | `HTTP GET /api/projects failed with 500: {"traceId":"abc123"}` |
| 500, empty body | `HTTP GET /api/projects failed with 500: no response body. Angular reported: …` |
| 400, validation | `HTTP GET /api/projects failed with 400: {"errors":{"ProjectName":["Project Name is required."]}}` |

The empty-500 case is the one worth noting: `JSON.stringify(null)` returns the string `"null"`, which is truthy and isn't `"{}"`, so it sailed past the obvious guard and logged `failed with 500: null`. Found only by printing actual output, and now pinned by a regression assertion.

## What changed

**400s surface the reason the request was rejected.** `ValidationProblemDetails` is checked before generic message extraction, because its `title` is only ever "One or more validation errors occurred." while the per-field entries say what to fix. Modelled on the equivalent handling in Qanat and Neptune, minus their `RowErrors` branch — that shape is specific to their bulk-import endpoints and this API never returns it.

The alert's unique code is per-**message**, not per-status. A page firing several requests gets the same rejection back several times over, and `alert-display` renders only the first three alerts, so with no code the duplicates of one message push every other field's error out of view entirely. A flat `"Http400"` would instead suppress the second and third field of a genuine multi-field failure. Both were observed, not reasoned about.

**Navigation and logout are gated on the request having gone to our own API.** The app also talks to WAMAS, Nominatim and GeoServer; a 404 from a geocoder belongs to whichever component asked for it, not to the router. The comparison is on a segment boundary, so a sibling path like `/apiary` cannot match a base of `/api`.

**Three dead redirect targets removed**, all ProjectFirma fork artifacts this app never defined routes for — so each fell through to the `"**"` custom-page handler and dumped the user on `/not-found`:

- **401** went to `/unauthenticated`, leaving the dead session cached so the 401 reproduced on every reload. Now the unusable session is discarded and a fresh sign-in starts — except for anonymous users, where a sign-out redirect would loop, so they get a message and stay put.
- **403** went to `/subscription-insufficient` (this app has no subscription concept), tearing down whatever modal made the request before it could report the failure. Now the server's message is surfaced and the component stays mounted.
- **404 on user-claims** was matched by the message `"User with GUID "`, which `UserClaimsController` has never returned — it says `"User with GlobalID … does not exist!"` — so the check was dead and those 404s were being redirected away from the login callback that creates the user. Matched on the endpoint instead of the message text.

## Verification

Nine Playwright specs, all passing, driving each failure shape through `page.route()`.

**Two of them were written wrong first, and both passed while testing nothing.** Worth reading if you review only one part of this.

The `isOurApi` gate was first checked by intercepting GeoServer on `/projects/map` and asserting no navigation. That page issues **zero** GeoServer requests through `HttpClient` — Leaflet fetches WMS tiles as `<img>`, and the WFS `GetFeature` only fires on a map click in a different component. It asserted against a request that never happened, and would have passed with the gate deleted. Rewritten to drive the real WAMAS geocoder on `/find-your-forester`, which renders `<map-search>` unconditionally rather than behind `*ngIf="mapIsReady"`, with a `routeHit` assertion so it cannot go quiet again.

That version *still* passed with the gate removed. The fulfilled 404 carried no `Access-Control-Allow-Origin`, so the browser rejected the cross-origin response and Angular reported status 0 — which never reaches the 404 branch at all. The header is load-bearing and is commented as such.

Every claim here is mutation-tested — the fix reverted, the test confirmed to fail, the fix restored:

| mutation | result |
|---|---|
| per-message `uniqueCode` removed | fails — `resolved to 2 elements`, and the second field's error never renders |
| flat `"Http400"` restored | fails — the second endpoint's different message never appears |
| escaping removed | fails — the markup becomes a live `<a>` element |
| `isOurApi` disabled | fails — an external 404 navigates to `/not-found` |
| all restored | 9/9 pass |

One process note: an earlier mutation run passed with the fix removed and nearly retired a real finding as unfounded. It was a stale bundle — Playwright ran 2.6s after the edit, before `ng serve` had rebuilt. Every mutation above now waits on the rebuild first.

`npx ng build` succeeds.

## Addressed in review

Three findings from review, all correct, fixed in `75bbf8232`:

1. **A flat `"Http400"` code survived on two of the three 400 paths.** The per-message code was added precisely because a flat one suppresses distinct messages — I applied it to `pushFieldMessages` and left the string-body and `ProblemDetails` calls flat, so the first such 400 on a page suppressed every *different* 400 after it. All three now route through one method. 401/403 stay flat deliberately, and that asymmetry is now written down.
2. **Alert text is escaped.** An earlier version of this description flagged the `[innerHTML]` surface but argued the sanitizer made it acceptable; that was wrong. It strips scripts and handlers but renders `<a href>` and `<img src>` happily, and 400s quote user-supplied values back, so one user can put a link or tracking pixel in another's alert without tripping it. Escaping now happens once at the leaf, leaving only the deliberate `<br/>`.
3. **The gate test's fixed 1s sleep is gone**, replaced by waiting *for* the undesired navigation and requiring it to time out. A fixed sleep passes on exactly the slow run most likely to be hiding a regression.

Two specs added, one per behaviour change, both mutation-tested. Suite is **9/9**. Typing the body as `unknown` and narrowing also cleared the 4 `no-unsafe-*` lint errors this branch had introduced into a previously clean file.

## Still not addressed

**The 401 `forcedLogout()` branch is untested.** It has the largest blast radius of anything here — a full-page Auth0 redirect — and the specs cover the anonymous half only. Driving the authed half needs a real session, and getting it wrong signs users out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
