### PR TITLE
WADNR-2287 Fix GIS bulk import project type mapping and restore dropped legacy behaviours

### DIFF
--- a/WADNR.API.Tests/GisBulkImportLegacyParityTests.cs
+++ b/WADNR.API.Tests/GisBulkImportLegacyParityTests.cs
@@ -1,0 +1,999 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NetTopologySuite.Geometries;
+using WADNR.EFModels.Entities;
+using WADNR.Models.DataTransferObjects.GisBulkImport;
+
+namespace WADNR.API.Tests;
+
+/// <summary>
+/// Covers the legacy GIS import behaviours the MVC-to-API rewrite dropped, found by auditing
+/// GisProjectBulkUpdateController against GisBulkImports.ImportProjectsAsync. Each of these was
+/// still configurable in the Program admin UI, so it read as working while doing nothing:
+///
+/// 1. GisExcludeIncludeColumns whitelist / blacklist filtering of features.
+/// 2. Private landowner ProjectPerson creation from the Landowner column.
+/// 3. DNR Service Forestry Regional Coordinator assignment on new LOA projects.
+/// 4. GisUploadSourceOrganization.RequiresCompletionDate() skip.
+/// 5. Setting Project.ProjectLocationPoint when the treatment proc is skipped.
+/// 6. Clearing the attempt's staged GIS features after a successful import.
+/// 7. Block-list entries that point at a ProjectID rather than an identifier or name.
+///
+/// The source org runs against the Landowner Assistance program, because that is the program whose
+/// production configuration exercises most of this (landowner column, regional coordinators).
+/// </summary>
+[TestClass]
+public class GisBulkImportLegacyParityTests
+{
+    // Fully qualified: bare `Program` binds to the API's ASP.NET entry-point class in this assembly.
+    private static readonly int ProgramID = WADNR.EFModels.Entities.Program.LandownerAssistanceProgramID;
+    private const int OtherProgramID = 99;
+    private const int SourceOrgID = 10;
+    private const int AttemptID = 100;
+
+    private const int IdentifierAttrID = 1;
+    private const int NameAttrID = 2;
+    private const int LandownerAttrID = 3;
+    private const int CompletionDateAttrID = 4;
+    private const int TechniqueAttrID = 5;
+
+    private const int OtherProjectTypeID = 99;
+    private const int OrganizationID = 1;
+    private const int RelationshipTypeID = 1;
+    private const int RegionCoordinatorPersonID = 555;
+    private const int DNRUplandRegionID = 1;
+
+    private static WADNRDbContext NewInMemoryContext()
+    {
+        var options = new DbContextOptionsBuilder<WADNRDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        return new WADNRDbContext(options);
+    }
+
+    private static Geometry MakeSquare(double offset = 0)
+    {
+        var factory = new GeometryFactory(new PrecisionModel(), 4326);
+        return factory.CreatePolygon(factory.CreateLinearRing(new[]
+        {
+            new Coordinate(-120.0 + offset, 47.0),
+            new Coordinate(-120.0 + offset, 47.1),
+            new Coordinate(-119.9 + offset, 47.1),
+            new Coordinate(-119.9 + offset, 47.0),
+            new Coordinate(-120.0 + offset, 47.0),
+        }));
+    }
+
+    /// <summary>One GIS feature's worth of metadata.</summary>
+    private sealed record FeatureSpec(
+        string Identifier,
+        string Name = "Test Project",
+        string? Landowner = null,
+        string? CompletionDate = null,
+        string? Technique = null);
+
+    private sealed class SeedOptions
+    {
+        public int ProjectStageDefaultID { get; init; } = (int)ProjectStageEnum.Implementation;
+        public bool DataDeriveProjectStage { get; init; }
+        public bool ImportAsDetailedLocationInsteadOfTreatments { get; init; }
+        public List<FeatureSpec> Features { get; init; } = new();
+
+        /// <summary>Configured include/exclude column, if any: (columnName, isWhitelist, values).</summary>
+        public (string ColumnName, bool IsWhitelist, string[] Values)? ExcludeIncludeColumn { get; init; }
+    }
+
+    private static async Task SeedAsync(WADNRDbContext db, SeedOptions options)
+    {
+        db.ProjectTypes.Add(new ProjectType { ProjectTypeID = OtherProjectTypeID, ProjectTypeName = "Other" });
+        db.Organizations.Add(new Organization
+        {
+            OrganizationID = OrganizationID,
+            OrganizationName = "Default Org",
+            OrganizationShortName = "DEF",
+            IsActive = true
+        });
+
+        db.GisUploadSourceOrganizations.Add(new GisUploadSourceOrganization
+        {
+            GisUploadSourceOrganizationID = SourceOrgID,
+            GisUploadSourceOrganizationName = "Parity Test Source",
+            ProgramID = ProgramID,
+            ProjectStageDefaultID = options.ProjectStageDefaultID,
+            ProjectTypeDefaultName = null,
+            DataDeriveProjectStage = options.DataDeriveProjectStage,
+            ImportAsDetailedLocationInsteadOfTreatments = options.ImportAsDetailedLocationInsteadOfTreatments,
+            DefaultLeadImplementerOrganizationID = OrganizationID,
+            RelationshipTypeForDefaultOrganizationID = RelationshipTypeID,
+            ApplyStartDateToProject = false,
+            ApplyCompletedDateToProject = false,
+        });
+
+        if (options.ExcludeIncludeColumn.HasValue)
+        {
+            var (columnName, isWhitelist, values) = options.ExcludeIncludeColumn.Value;
+            db.GisExcludeIncludeColumns.Add(new GisExcludeIncludeColumn
+            {
+                GisExcludeIncludeColumnID = 1,
+                GisUploadSourceOrganizationID = SourceOrgID,
+                GisDefaultMappingColumnName = columnName,
+                IsWhitelist = isWhitelist,
+            });
+            var valueID = 1;
+            foreach (var value in values)
+            {
+                db.GisExcludeIncludeColumnValues.Add(new GisExcludeIncludeColumnValue
+                {
+                    GisExcludeIncludeColumnValueID = valueID++,
+                    GisExcludeIncludeColumnID = 1,
+                    GisExcludeIncludeColumnValueForFiltering = value,
+                });
+            }
+        }
+
+        db.GisUploadAttempts.Add(new GisUploadAttempt
+        {
+            GisUploadAttemptID = AttemptID,
+            GisUploadSourceOrganizationID = SourceOrgID,
+            GisUploadAttemptCreatePersonID = 1,
+            GisUploadAttemptCreateDate = new DateTime(2026, 8, 17, 0, 0, 0, DateTimeKind.Utc),
+        });
+
+        db.GisMetadataAttributes.Add(new GisMetadataAttribute { GisMetadataAttributeID = IdentifierAttrID, GisMetadataAttributeName = "project_id" });
+        db.GisMetadataAttributes.Add(new GisMetadataAttribute { GisMetadataAttributeID = NameAttrID, GisMetadataAttributeName = "project_name" });
+        db.GisMetadataAttributes.Add(new GisMetadataAttribute { GisMetadataAttributeID = LandownerAttrID, GisMetadataAttributeName = "landowner" });
+        db.GisMetadataAttributes.Add(new GisMetadataAttribute { GisMetadataAttributeID = CompletionDateAttrID, GisMetadataAttributeName = "completed" });
+        db.GisMetadataAttributes.Add(new GisMetadataAttribute { GisMetadataAttributeID = TechniqueAttrID, GisMetadataAttributeName = "technique_cd" });
+
+        var featureID = 1000;
+        var metaID = 1;
+        for (var i = 0; i < options.Features.Count; i++)
+        {
+            var spec = options.Features[i];
+            db.GisFeatures.Add(new GisFeature
+            {
+                GisFeatureID = featureID,
+                GisUploadAttemptID = AttemptID,
+                GisFeatureGeometry = MakeSquare(i * 0.5),
+                GisImportFeatureKey = i,
+                IsValid = true,
+            });
+
+            void AddMetadata(int attributeID, string? value)
+            {
+                if (value == null) return;
+                db.GisFeatureMetadataAttributes.Add(new GisFeatureMetadataAttribute
+                {
+                    GisFeatureMetadataAttributeID = metaID++,
+                    GisFeatureID = featureID,
+                    GisMetadataAttributeID = attributeID,
+                    GisFeatureMetadataAttributeValue = value,
+                });
+            }
+
+            AddMetadata(IdentifierAttrID, spec.Identifier);
+            AddMetadata(NameAttrID, spec.Name);
+            AddMetadata(LandownerAttrID, spec.Landowner);
+            AddMetadata(CompletionDateAttrID, spec.CompletionDate);
+            AddMetadata(TechniqueAttrID, spec.Technique);
+
+            featureID++;
+        }
+
+        await db.SaveChangesWithNoAuditingAsync();
+    }
+
+    private static GisBulkImportRequest BuildRequest(bool mapLandowner = false) => new()
+    {
+        ProjectIdentifierMetadataAttributeID = IdentifierAttrID,
+        ProjectNameMetadataAttributeID = NameAttrID,
+        CompletionDateMetadataAttributeID = CompletionDateAttrID,
+        PrivateLandownerMetadataAttributeID = mapLandowner ? LandownerAttrID : null,
+    };
+
+    // ---------------------------------------------------------------------------------------
+    // 1. Include / exclude column filtering
+    // ---------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ImportProjects_DropsBlacklistedFeatures()
+    {
+        // Mirrors DNR State Lands' production configuration: a blacklist on technique_cd.
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ExcludeIncludeColumn = ("technique_cd", false, new[] { "NATURAL", "SEED_GRASS" }),
+            Features =
+            {
+                new FeatureSpec("PROJ-1", Technique: "PCT"),
+                new FeatureSpec("PROJ-2", Technique: "NATURAL"),
+                new FeatureSpec("PROJ-3", Technique: "SEED_GRASS"),
+            }
+        });
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsCreated, "Only the non-blacklisted feature may produce a project.");
+        Assert.AreEqual("PROJ-1", (await db.Projects.SingleAsync()).ProjectGisIdentifier);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_KeepsOnlyWhitelistedFeatures()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ExcludeIncludeColumn = ("technique_cd", true, new[] { "PCT" }),
+            Features =
+            {
+                new FeatureSpec("PROJ-1", Technique: "PCT"),
+                new FeatureSpec("PROJ-2", Technique: "NATURAL"),
+            }
+        });
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsCreated);
+        Assert.AreEqual("PROJ-1", (await db.Projects.SingleAsync()).ProjectGisIdentifier);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_MatchesFilterValuesCaseInsensitively()
+    {
+        // Legacy compared ordinally, but the upload path lowercases attribute names, so an ordinal
+        // match on a mixed-case configured column name would silently never fire.
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ExcludeIncludeColumn = ("TECHNIQUE_CD", false, new[] { "natural" }),
+            Features =
+            {
+                new FeatureSpec("PROJ-1", Technique: "PCT"),
+                new FeatureSpec("PROJ-2", Technique: "NATURAL"),
+            }
+        });
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsCreated);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_ReportsHowManyFeaturesWereExcluded()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            ExcludeIncludeColumn = ("technique_cd", false, new[] { "NATURAL" }),
+            Features =
+            {
+                new FeatureSpec("PROJ-1", Technique: "PCT"),
+                new FeatureSpec("PROJ-2", Technique: "NATURAL"),
+            }
+        });
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.Warnings.Count, "Excluding features silently would look like data loss.");
+        StringAssert.Contains(result.Warnings[0], "Excluded 1 of 2 features");
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_IgnoresFilterConfiguredAgainstAnAbsentColumn()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ExcludeIncludeColumn = ("no_such_column", true, new[] { "PCT" }),
+            Features = { new FeatureSpec("PROJ-1", Technique: "PCT") }
+        });
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsCreated,
+            "A whitelist on a column this upload doesn't carry must not silently discard everything.");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 2. Private landowners
+    // ---------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ImportProjects_CreatesPersonAndProjectPerson_ForNewLandowner()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1", Landowner: "Nakamura, Rose") }
+        });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest(mapLandowner: true));
+
+        var person = await db.People.SingleAsync();
+        Assert.AreEqual("Rose", person.FirstName, "\"Last, First\" must split on the comma.");
+        Assert.AreEqual("Nakamura", person.LastName);
+        Assert.IsTrue(person.CreatedAsPartOfBulkImport);
+
+        var projectPerson = await db.ProjectPeople.SingleAsync();
+        Assert.AreEqual(person.PersonID, projectPerson.PersonID);
+        Assert.AreEqual(ProjectPersonRelationshipType.PrivateLandowner.ProjectPersonRelationshipTypeID,
+            projectPerson.ProjectPersonRelationshipTypeID);
+        Assert.AreEqual(1, await db.PersonRoles.CountAsync(x => x.PersonID == person.PersonID && x.RoleID == Role.Unassigned.RoleID));
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_TreatsUnpunctuatedLandownerAsAWholeFirstName()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1", Landowner: "Cascade Timber LLC") }
+        });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest(mapLandowner: true));
+
+        var person = await db.People.SingleAsync();
+        Assert.AreEqual("Cascade Timber LLC", person.FirstName);
+        Assert.IsNull(person.LastName);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_ReusesExistingPerson_WhenLandownerAlreadyExists()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1", Landowner: "nakamura, rose") }
+        });
+        db.People.Add(new Person
+        {
+            PersonID = 42,
+            FirstName = "Rose",
+            LastName = "Nakamura",
+            CreateDate = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            IsActive = true,
+        });
+        await db.SaveChangesWithNoAuditingAsync();
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest(mapLandowner: true));
+
+        Assert.AreEqual(1, await db.People.CountAsync(), "Matching is case-insensitive, so no duplicate Person.");
+        Assert.AreEqual(42, (await db.ProjectPeople.SingleAsync()).PersonID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_CreatesLandownerOnce_WhenTwoFeaturesShareTheSameName()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features =
+            {
+                new FeatureSpec("PROJ-1", Landowner: "Nakamura, Rose"),
+                new FeatureSpec("PROJ-2", Landowner: "Nakamura, Rose"),
+            }
+        });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest(mapLandowner: true));
+
+        Assert.AreEqual(1, await db.People.CountAsync(),
+            "The in-memory index must be kept in step, or each project invents its own copy of the person.");
+        Assert.AreEqual(2, await db.ProjectPeople.CountAsync());
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_SkipsLandownerValueThatYieldsNoName()
+    {
+        // "Smith," splits to an empty first name. Legacy would have created a nameless Person.
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1", Landowner: "Smith,") }
+        });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest(mapLandowner: true));
+
+        Assert.AreEqual(0, await db.People.CountAsync(), "A landowner value with no first name must not create a Person.");
+        Assert.AreEqual(0, await db.ProjectPeople.CountAsync());
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_LeavesLandownersAlone_WhenLandownerColumnNotMapped()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1", Landowner: "Nakamura, Rose") }
+        });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest(mapLandowner: false));
+
+        Assert.AreEqual(0, await db.People.CountAsync());
+        Assert.AreEqual(0, await db.ProjectPeople.CountAsync());
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 3. Service Forestry Regional Coordinator
+    // ---------------------------------------------------------------------------------------
+
+    private static async Task SeedRegionWithCoordinatorAsync(WADNRDbContext db, int? coordinatorPersonID)
+    {
+        if (coordinatorPersonID.HasValue)
+        {
+            db.People.Add(new Person
+            {
+                PersonID = coordinatorPersonID.Value,
+                FirstName = "Regional",
+                LastName = "Coordinator",
+                CreateDate = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                IsActive = true,
+            });
+        }
+
+        db.DNRUplandRegions.Add(new DNRUplandRegion
+        {
+            DNRUplandRegionID = DNRUplandRegionID,
+            DNRUplandRegionName = "Northeast",
+            DNRUplandRegionLocation = MakeSquare(),
+            DNRUplandRegionCoordinatorID = coordinatorPersonID,
+        });
+        await db.SaveChangesWithNoAuditingAsync();
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_AssignsRegionalCoordinator_ToNewLandownerAssistanceProject()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1") }
+        });
+        await SeedRegionWithCoordinatorAsync(db, RegionCoordinatorPersonID);
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        var projectPerson = await db.ProjectPeople.SingleAsync();
+        Assert.AreEqual(RegionCoordinatorPersonID, projectPerson.PersonID);
+        Assert.AreEqual(ProjectPersonRelationshipType.ServiceForestryRegionalCoordinator.ProjectPersonRelationshipTypeID,
+            projectPerson.ProjectPersonRelationshipTypeID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_AssignsNoCoordinator_WhenRegionHasNone()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1") }
+        });
+        await SeedRegionWithCoordinatorAsync(db, coordinatorPersonID: null);
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(0, await db.ProjectPeople.CountAsync());
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_AssignsCoordinatorOnlyOnce_WhenRunTwice()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1") }
+        });
+        await SeedRegionWithCoordinatorAsync(db, RegionCoordinatorPersonID);
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, await db.ProjectPeople.CountAsync(),
+            "Re-running the import must not stack duplicate coordinator rows.");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 4. RequiresCompletionDate
+    // ---------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ImportProjects_SkipsProject_WhenStageDefaultIsCompletedAndNoCompletionDate()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ProjectStageDefaultID = ProjectStage.Completed.ProjectStageID,
+            DataDeriveProjectStage = false,
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features =
+            {
+                new FeatureSpec("PROJ-1", CompletionDate: "2026-05-01"),
+                new FeatureSpec("PROJ-2", CompletionDate: null),
+            }
+        });
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsCreated);
+        Assert.AreEqual("PROJ-1", (await db.Projects.SingleAsync()).ProjectGisIdentifier);
+        Assert.IsTrue(result.Warnings.Any(w => w.Contains("Skipped 1 project")),
+            $"Expected the skip to be reported. Warnings: {string.Join(" | ", result.Warnings)}");
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_DoesNotSkip_WhenStageIsDerivedFromData()
+    {
+        // RequiresCompletionDate() is false when the stage comes from the data, so nothing is dropped.
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ProjectStageDefaultID = ProjectStage.Completed.ProjectStageID,
+            DataDeriveProjectStage = true,
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1", CompletionDate: null) }
+        });
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsCreated);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_DoesNotSkip_WhenStageDefaultIsNotCompleted()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ProjectStageDefaultID = (int)ProjectStageEnum.Implementation,
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1", CompletionDate: null) }
+        });
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsCreated);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 5. Simple location point when the treatment proc is skipped
+    // ---------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ImportProjects_SetsProjectLocationPoint_WhenTreatmentProcIsSkipped()
+    {
+        // The proc's final statement normally sets these; gating it off for detailed-location
+        // sources would otherwise leave them with no simple location at all.
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1") }
+        });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        var project = await db.Projects.SingleAsync();
+        Assert.IsNotNull(project.ProjectLocationPoint, "Expected a centroid derived from the imported project areas.");
+        Assert.AreEqual((int)ProjectLocationSimpleTypeEnum.PointOnMap, project.ProjectLocationSimpleTypeID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_LeavesLocationPointNull_WhenBlockedProjectHasNoProjectAreas()
+    {
+        // Everything in the upload is blocked, so no project areas exist to build a centroid from.
+        // The centroid pass must handle that rather than throwing on an empty geometry set.
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1", Name: "Renamed") }
+        });
+        db.Projects.Add(new Project
+        {
+            ProjectID = 500,
+            ProjectName = "Blocked",
+            FhtProjectNumber = "FHT-2026-00001",
+            ProjectGisIdentifier = "PROJ-1",
+            ProjectTypeID = OtherProjectTypeID,
+            ProjectStageID = (int)ProjectStageEnum.Implementation,
+            ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Approved,
+            ProjectLocationSimpleTypeID = (int)ProjectLocationSimpleTypeEnum.None,
+        });
+        db.ProjectPrograms.Add(new ProjectProgram { ProjectID = 500, ProgramID = ProgramID });
+        db.ProjectImportBlockLists.Add(new ProjectImportBlockList
+        {
+            ProjectImportBlockListID = 1,
+            ProgramID = ProgramID,
+            ProjectID = 500,
+        });
+        await db.SaveChangesWithNoAuditingAsync();
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsBlocked);
+        db.ChangeTracker.Clear();
+        Assert.IsNull((await db.Projects.SingleAsync()).ProjectLocationPoint);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Update-path branches
+    // ---------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ImportProjects_ApprovesDraftProject_AndFillsStartDateAndDescription_OnUpdate()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1", CompletionDate: "2026-06-01") }
+        });
+        var sourceOrg = db.GisUploadSourceOrganizations.Single();
+        sourceOrg.ApplyStartDateToProject = true;
+        sourceOrg.ProjectDescriptionDefaultText = "Imported from the source organization.";
+
+        db.Projects.Add(new Project
+        {
+            ProjectID = 500,
+            ProjectName = "Existing",
+            FhtProjectNumber = "FHT-2026-00001",
+            ProjectGisIdentifier = "PROJ-1",
+            ProjectTypeID = OtherProjectTypeID,
+            ProjectStageID = (int)ProjectStageEnum.Planned,
+            ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Draft,
+            ProjectLocationSimpleTypeID = (int)ProjectLocationSimpleTypeEnum.None,
+            ProjectDescription = null,
+        });
+        db.ProjectPrograms.Add(new ProjectProgram { ProjectID = 500, ProgramID = ProgramID });
+        await db.SaveChangesWithNoAuditingAsync();
+
+        var request = DateRequest();
+        request.StartDateMetadataAttributeID = CompletionDateAttrID; // reuse the same column as a start date
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, request);
+
+        Assert.AreEqual(1, result.ProjectsUpdated);
+        db.ChangeTracker.Clear();
+        var project = await db.Projects.SingleAsync();
+        Assert.AreEqual((int)ProjectApprovalStatusEnum.Approved, project.ProjectApprovalStatusID,
+            "A Draft project moving to a non-Planned stage must be auto-approved.");
+        Assert.AreEqual(new DateOnly(2026, 6, 1), project.PlannedDate);
+        Assert.AreEqual("Imported from the source organization.", project.ProjectDescription,
+            "An empty description must be filled from the source organization default.");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 6. Staged feature cleanup
+    // ---------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ImportProjects_ClearsStagedFeatures_AfterSuccessfulImport()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1") }
+        });
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(0, result.Warnings.Count);
+        Assert.AreEqual(0, await db.GisFeatures.CountAsync());
+        Assert.AreEqual(0, await db.GisFeatureMetadataAttributes.CountAsync());
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_RetainsStagedFeatures_WhenAnythingWentWrong()
+    {
+        // The treatment proc can't run on the in-memory provider, which produces a warning — exactly
+        // the case where the staged data must survive so the failure can be diagnosed.
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = false,
+            Features = { new FeatureSpec("PROJ-1") }
+        });
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreNotEqual(0, result.Warnings.Count);
+        Assert.AreEqual(1, await db.GisFeatures.CountAsync());
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 8. Date resolution (epoch fallback, earliest/latest across features, cross-program widening)
+    // ---------------------------------------------------------------------------------------
+
+    private static SeedOptions DateOptions(params FeatureSpec[] features) => new()
+    {
+        ImportAsDetailedLocationInsteadOfTreatments = true,
+        Features = features.ToList(),
+    };
+
+    private static GisBulkImportRequest DateRequest() => new()
+    {
+        ProjectIdentifierMetadataAttributeID = IdentifierAttrID,
+        ProjectNameMetadataAttributeID = NameAttrID,
+        CompletionDateMetadataAttributeID = CompletionDateAttrID,
+    };
+
+    [TestMethod]
+    public async Task ImportProjects_ParsesEpochMillisecondDates_FromArcGisOnline()
+    {
+        // The nightly LOA / USFS jobs stage Esri date fields as epoch milliseconds. Parsing them only
+        // with DateTime.TryParse meant those imports silently resolved no dates at all.
+        var epochMillis = new DateTimeOffset(new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
+
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, DateOptions(new FeatureSpec("PROJ-1", CompletionDate: epochMillis.ToString())));
+        db.GisUploadSourceOrganizations.Single().ApplyCompletedDateToProject = true;
+        await db.SaveChangesWithNoAuditingAsync();
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, DateRequest());
+
+        Assert.AreEqual(new DateOnly(2026, 5, 1), (await db.Projects.SingleAsync()).CompletionDate);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_TakesLatestCompletionDateAcrossAllFeaturesOfAProject()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, DateOptions(
+            new FeatureSpec("PROJ-1", CompletionDate: "2026-01-15"),
+            new FeatureSpec("PROJ-1", CompletionDate: "2026-07-20"),
+            new FeatureSpec("PROJ-1", CompletionDate: "2026-03-02")));
+        db.GisUploadSourceOrganizations.Single().ApplyCompletedDateToProject = true;
+        await db.SaveChangesWithNoAuditingAsync();
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, DateRequest());
+
+        Assert.AreEqual(new DateOnly(2026, 7, 20), (await db.Projects.SingleAsync()).CompletionDate,
+            "The completion date must be the latest across the project's features, not the first one seen.");
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_PrefersRealDatesOverEpochInterpretation()
+    {
+        // The epoch fallback only applies when nothing parsed as a date, so a normal GDB upload is
+        // never reinterpreted as milliseconds.
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, DateOptions(new FeatureSpec("PROJ-1", CompletionDate: "2026-05-01")));
+        db.GisUploadSourceOrganizations.Single().ApplyCompletedDateToProject = true;
+        await db.SaveChangesWithNoAuditingAsync();
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, DateRequest());
+
+        Assert.AreEqual(new DateOnly(2026, 5, 1), (await db.Projects.SingleAsync()).CompletionDate);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_TreatsEpochCompletionDateAsPresent_ForStageDerivation()
+    {
+        // DNR LOA NE derives its stage and is fed by the AGOL job. If an epoch completion date reads
+        // as "no completion date", every LOA project silently drops to Planned.
+        await using var db = NewInMemoryContext();
+        var epochMillis = new DateTimeOffset(new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
+        await SeedAsync(db, new SeedOptions
+        {
+            ProjectStageDefaultID = ProjectStage.Completed.ProjectStageID,
+            DataDeriveProjectStage = true,
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1", CompletionDate: epochMillis.ToString()) }
+        });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, DateRequest());
+
+        Assert.AreEqual(ProjectStage.Completed.ProjectStageID, (await db.Projects.SingleAsync()).ProjectStageID,
+            "An epoch completion date must count as a completion date, or the stage falls back to Planned.");
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_WidensCompletionDate_ToCoverAnotherProgramsTreatments()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, DateOptions(new FeatureSpec("PROJ-1", CompletionDate: "2026-01-15")));
+        db.GisUploadSourceOrganizations.Single().ApplyCompletedDateToProject = true;
+
+        db.Projects.Add(new Project
+        {
+            ProjectID = 500,
+            ProjectName = "Shared Project",
+            FhtProjectNumber = "FHT-2026-00001",
+            ProjectGisIdentifier = "PROJ-1",
+            ProjectTypeID = OtherProjectTypeID,
+            ProjectStageID = (int)ProjectStageEnum.Implementation,
+            ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Approved,
+            ProjectLocationSimpleTypeID = (int)ProjectLocationSimpleTypeEnum.None,
+        });
+        db.ProjectPrograms.Add(new ProjectProgram { ProjectID = 500, ProgramID = ProgramID });
+        db.Treatments.Add(new Treatment
+        {
+            TreatmentID = 1,
+            ProjectID = 500,
+            ProgramID = OtherProgramID,
+            TreatmentTypeID = TreatmentType.Other.TreatmentTypeID,
+            TreatmentDetailedActivityTypeID = TreatmentDetailedActivityType.Other.TreatmentDetailedActivityTypeID,
+            TreatmentFootprintAcres = 5m,
+            TreatmentEndDate = new DateOnly(2026, 9, 30),
+        });
+        await db.SaveChangesWithNoAuditingAsync();
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, DateRequest());
+
+        Assert.AreEqual(new DateOnly(2026, 9, 30), (await db.Projects.SingleAsync()).CompletionDate,
+            "A project shared across programs must keep a span covering the other program's treatments.");
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_WidensStartDate_ToCoverAnotherProgramsTreatments()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1", CompletionDate: "2026-06-01") }
+        });
+        var sourceOrg = db.GisUploadSourceOrganizations.Single();
+        sourceOrg.ApplyStartDateToProject = true;
+
+        db.Projects.Add(new Project
+        {
+            ProjectID = 500,
+            ProjectName = "Shared Project",
+            FhtProjectNumber = "FHT-2026-00001",
+            ProjectGisIdentifier = "PROJ-1",
+            ProjectTypeID = OtherProjectTypeID,
+            ProjectStageID = (int)ProjectStageEnum.Implementation,
+            ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Approved,
+            ProjectLocationSimpleTypeID = (int)ProjectLocationSimpleTypeEnum.None,
+        });
+        db.ProjectPrograms.Add(new ProjectProgram { ProjectID = 500, ProgramID = ProgramID });
+        db.Treatments.Add(new Treatment
+        {
+            TreatmentID = 1,
+            ProjectID = 500,
+            ProgramID = OtherProgramID,
+            TreatmentTypeID = TreatmentType.Other.TreatmentTypeID,
+            TreatmentDetailedActivityTypeID = TreatmentDetailedActivityType.Other.TreatmentDetailedActivityTypeID,
+            TreatmentFootprintAcres = 5m,
+            TreatmentStartDate = new DateOnly(2025, 2, 3),
+        });
+        await db.SaveChangesWithNoAuditingAsync();
+
+        var request = DateRequest();
+        request.StartDateMetadataAttributeID = null; // no start date in the GIS data at all
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, request);
+
+        Assert.AreEqual(new DateOnly(2025, 2, 3), (await db.Projects.SingleAsync()).PlannedDate,
+            "The start date must reach back to cover the earliest treatment from another program.");
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_IgnoresSameProgramTreatments_WhenWideningDates()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, DateOptions(new FeatureSpec("PROJ-1", CompletionDate: "2026-01-15")));
+        db.GisUploadSourceOrganizations.Single().ApplyCompletedDateToProject = true;
+
+        db.Projects.Add(new Project
+        {
+            ProjectID = 500,
+            ProjectName = "Shared Project",
+            FhtProjectNumber = "FHT-2026-00001",
+            ProjectGisIdentifier = "PROJ-1",
+            ProjectTypeID = OtherProjectTypeID,
+            ProjectStageID = (int)ProjectStageEnum.Implementation,
+            ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Approved,
+            ProjectLocationSimpleTypeID = (int)ProjectLocationSimpleTypeEnum.None,
+        });
+        db.ProjectPrograms.Add(new ProjectProgram { ProjectID = 500, ProgramID = ProgramID });
+        db.Treatments.Add(new Treatment
+        {
+            TreatmentID = 1,
+            ProjectID = 500,
+            ProgramID = ProgramID,
+            TreatmentTypeID = TreatmentType.Other.TreatmentTypeID,
+            TreatmentDetailedActivityTypeID = TreatmentDetailedActivityType.Other.TreatmentDetailedActivityTypeID,
+            TreatmentFootprintAcres = 5m,
+            TreatmentEndDate = new DateOnly(2026, 9, 30),
+        });
+        await db.SaveChangesWithNoAuditingAsync();
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, DateRequest());
+
+        Assert.AreEqual(new DateOnly(2026, 1, 15), (await db.Projects.SingleAsync()).CompletionDate,
+            "This program's own treatments are being replaced by the import, so they must not widen the span.");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 7. Block list by ProjectID
+    // ---------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ImportProjects_SkipsProject_WhenBlockListEntryPointsAtItsProjectID()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1", Name: "Renamed By GIS") }
+        });
+
+        db.Projects.Add(new Project
+        {
+            ProjectID = 500,
+            ProjectName = "Do Not Touch",
+            FhtProjectNumber = "FHT-2026-00001",
+            ProjectGisIdentifier = "PROJ-1",
+            ProjectTypeID = OtherProjectTypeID,
+            ProjectStageID = (int)ProjectStageEnum.Implementation,
+            ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Approved,
+            ProjectLocationSimpleTypeID = (int)ProjectLocationSimpleTypeEnum.None,
+        });
+        db.ProjectPrograms.Add(new ProjectProgram { ProjectID = 500, ProgramID = ProgramID });
+        db.ProjectImportBlockLists.Add(new ProjectImportBlockList
+        {
+            ProjectImportBlockListID = 1,
+            ProgramID = ProgramID,
+            ProjectID = 500,
+        });
+        await db.SaveChangesWithNoAuditingAsync();
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsBlocked);
+        Assert.AreEqual(0, result.ProjectsUpdated);
+        Assert.AreEqual(0, result.ProjectsCreated);
+
+        db.ChangeTracker.Clear();
+        var project = await db.Projects.SingleAsync();
+        Assert.AreEqual("Do Not Touch", project.ProjectName, "A blocked project must not be renamed from the GIS data.");
+        Assert.AreEqual(0, await db.ProjectLocations.CountAsync(), "A blocked project must not get imported locations.");
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_DoesNotBlock_WhenBlockListEntryIsForAnotherProgram()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+            Features = { new FeatureSpec("PROJ-1") }
+        });
+
+        db.Projects.Add(new Project
+        {
+            ProjectID = 500,
+            ProjectName = "Existing",
+            FhtProjectNumber = "FHT-2026-00001",
+            ProjectGisIdentifier = "PROJ-1",
+            ProjectTypeID = OtherProjectTypeID,
+            ProjectStageID = (int)ProjectStageEnum.Implementation,
+            ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Approved,
+            ProjectLocationSimpleTypeID = (int)ProjectLocationSimpleTypeEnum.None,
+        });
+        db.ProjectPrograms.Add(new ProjectProgram { ProjectID = 500, ProgramID = ProgramID });
+        db.ProjectImportBlockLists.Add(new ProjectImportBlockList
+        {
+            ProjectImportBlockListID = 1,
+            ProgramID = OtherProgramID,
+            ProjectID = 500,
+        });
+        await db.SaveChangesWithNoAuditingAsync();
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(0, result.ProjectsBlocked);
+        Assert.AreEqual(1, result.ProjectsUpdated);
+    }
+}

--- a/WADNR.API.Tests/GisBulkImportProjectTypeTests.cs
+++ b/WADNR.API.Tests/GisBulkImportProjectTypeTests.cs
@@ -1,0 +1,695 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NetTopologySuite.Geometries;
+using WADNR.EFModels.Entities;
+using WADNR.Models.DataTransferObjects.GisBulkImport;
+
+namespace WADNR.API.Tests;
+
+/// <summary>
+/// Covers WADNR-2287: the GDB bulk import mis-mapped Project Type, and four other behaviours the
+/// MVC-to-API rewrite silently dropped while leaving their configuration editable in the Program
+/// admin UI.
+///
+/// 1. New projects fell back to <c>ProjectTypes.First()</c> — the lowest ProjectTypeID, which in
+///    production is "Research and Monitoring" — instead of "Other".
+/// 2. <c>AdjustProjectTypeBasedOnTreatmentTypes</c> was never honoured.
+/// 3. <c>DataDeriveProjectStage</c> + the ProjectStage crosswalk were never applied.
+/// 4. The LeadImplementer organization crosswalk was never applied.
+/// 5. <c>ImportAsDetailedLocationInsteadOfTreatments</c> did not gate the treatment proc.
+/// 6. <c>GisUploadProgramMergeGrouping</c> did not widen cross-program project matching.
+///
+/// Note on the treatment proc: the in-memory provider cannot run
+/// dbo.procImportTreatmentsFromGisUploadAttempt, so any import that reaches it records a warning and
+/// skips the project-type derivation (by design — we never derive from a partial treatment set).
+/// Tests that exercise the derivation therefore set ImportAsDetailedLocationInsteadOfTreatments,
+/// which is also how they assert behaviour 5.
+/// </summary>
+[TestClass]
+public class GisBulkImportProjectTypeTests
+{
+    private const int ProgramID = 1;
+    private const int SiblingProgramID = 2;
+    private const int SourceOrgID = 10;
+    private const int SiblingSourceOrgID = 11;
+    private const int AttemptID = 100;
+    private const int MergeGroupingID = 7;
+
+    private const int IdentifierAttrID = 1;
+    private const int NameAttrID = 2;
+    private const int StageAttrID = 3;
+    private const int LeadImplementerAttrID = 4;
+    private const int CompletionDateAttrID = 5;
+
+    // Deliberately the lowest ProjectTypeID in every seed, so a reintroduced `.First()` fallback
+    // lands here and fails the test. This mirrors production, where "Research and Monitoring" is
+    // ProjectTypeID 2218 — the lowest in dbo.ProjectType.
+    private const int ResearchAndMonitoringProjectTypeID = 1;
+    private const int CommercialProjectTypeID = 50;
+    private const int NonCommercialProjectTypeID = 51;
+    private const int PrescribedFireProjectTypeID = 52;
+    private const int OtherProjectTypeID = 99;
+
+    private const int DefaultOrganizationID = 1;
+    private const int CrosswalkedOrganizationID = 7;
+    private const int RelationshipTypeID = 1;
+
+    private const int ExistingProjectID = 500;
+
+    private static WADNRDbContext NewInMemoryContext()
+    {
+        var options = new DbContextOptionsBuilder<WADNRDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        return new WADNRDbContext(options);
+    }
+
+    private static Geometry MakeSquare()
+    {
+        var factory = new GeometryFactory(new PrecisionModel(), 4326);
+        var ring = factory.CreateLinearRing(new[]
+        {
+            new Coordinate(-120.0, 47.0),
+            new Coordinate(-120.0, 47.1),
+            new Coordinate(-119.9, 47.1),
+            new Coordinate(-119.9, 47.0),
+            new Coordinate(-120.0, 47.0),
+        });
+        return factory.CreatePolygon(ring);
+    }
+
+    private static void SeedProjectTypes(WADNRDbContext db, bool includeOther = true)
+    {
+        db.ProjectTypes.Add(new ProjectType { ProjectTypeID = ResearchAndMonitoringProjectTypeID, ProjectTypeName = "Research and Monitoring" });
+        db.ProjectTypes.Add(new ProjectType { ProjectTypeID = CommercialProjectTypeID, ProjectTypeName = "Commercial vegetation treatment" });
+        db.ProjectTypes.Add(new ProjectType { ProjectTypeID = NonCommercialProjectTypeID, ProjectTypeName = "Non-commercial vegetation treatment" });
+        db.ProjectTypes.Add(new ProjectType { ProjectTypeID = PrescribedFireProjectTypeID, ProjectTypeName = "Prescribed fire treatment" });
+        if (includeOther)
+        {
+            db.ProjectTypes.Add(new ProjectType { ProjectTypeID = OtherProjectTypeID, ProjectTypeName = "Other" });
+        }
+    }
+
+    private sealed class SeedOptions
+    {
+        public string? ProjectTypeDefaultName { get; init; }
+        public bool AdjustProjectTypeBasedOnTreatmentTypes { get; init; }
+        public bool DataDeriveProjectStage { get; init; }
+        public bool ImportAsDetailedLocationInsteadOfTreatments { get; init; }
+        public bool? ImportIsFlattened { get; init; }
+        public bool IncludeOtherProjectType { get; init; } = true;
+        public int? MergeGroupingID { get; init; }
+
+        public string? StageValue { get; init; }
+        public string? LeadImplementerValue { get; init; }
+        public string? CompletionDateValue { get; init; }
+
+        public List<(string SourceValue, string MappedValue)> ProjectStageCrossWalks { get; init; } = new();
+        public List<(string SourceValue, string MappedValue)> LeadImplementerCrossWalks { get; init; } = new();
+    }
+
+    /// <summary>
+    /// Seeds a single-feature upload for identifier "PROJ-1" against a source org configured by
+    /// <paramref name="options"/>.
+    /// </summary>
+    private static async Task SeedAsync(WADNRDbContext db, SeedOptions options)
+    {
+        SeedProjectTypes(db, options.IncludeOtherProjectType);
+
+        db.Organizations.Add(new Organization { OrganizationID = DefaultOrganizationID, OrganizationName = "Default Org", OrganizationShortName = "DEF", IsActive = true });
+        db.Organizations.Add(new Organization { OrganizationID = CrosswalkedOrganizationID, OrganizationName = "Crosswalked Org", OrganizationShortName = "XWALK", IsActive = true });
+
+        if (options.MergeGroupingID.HasValue)
+        {
+            db.GisUploadProgramMergeGroupings.Add(new GisUploadProgramMergeGrouping
+            {
+                GisUploadProgramMergeGroupingID = options.MergeGroupingID.Value,
+                GisUploadProgramMergeGroupingName = "Test Merge Grouping"
+            });
+        }
+
+        db.GisUploadSourceOrganizations.Add(new GisUploadSourceOrganization
+        {
+            GisUploadSourceOrganizationID = SourceOrgID,
+            GisUploadSourceOrganizationName = "Test Source",
+            ProgramID = ProgramID,
+            ProjectStageDefaultID = (int)ProjectStageEnum.Implementation,
+            ProjectTypeDefaultName = options.ProjectTypeDefaultName,
+            AdjustProjectTypeBasedOnTreatmentTypes = options.AdjustProjectTypeBasedOnTreatmentTypes,
+            DataDeriveProjectStage = options.DataDeriveProjectStage,
+            ImportAsDetailedLocationInsteadOfTreatments = options.ImportAsDetailedLocationInsteadOfTreatments,
+            ImportIsFlattened = options.ImportIsFlattened,
+            GisUploadProgramMergeGroupingID = options.MergeGroupingID,
+            DefaultLeadImplementerOrganizationID = DefaultOrganizationID,
+            RelationshipTypeForDefaultOrganizationID = RelationshipTypeID,
+            ApplyStartDateToProject = false,
+            ApplyCompletedDateToProject = false,
+        });
+
+        if (options.MergeGroupingID.HasValue)
+        {
+            // A sibling source org in the same merge grouping, covering a different program.
+            db.GisUploadSourceOrganizations.Add(new GisUploadSourceOrganization
+            {
+                GisUploadSourceOrganizationID = SiblingSourceOrgID,
+                GisUploadSourceOrganizationName = "Sibling Source",
+                ProgramID = SiblingProgramID,
+                ProjectStageDefaultID = (int)ProjectStageEnum.Implementation,
+                GisUploadProgramMergeGroupingID = options.MergeGroupingID,
+                DefaultLeadImplementerOrganizationID = DefaultOrganizationID,
+                RelationshipTypeForDefaultOrganizationID = RelationshipTypeID,
+            });
+        }
+
+        var crossWalkID = 1;
+        foreach (var (sourceValue, mappedValue) in options.ProjectStageCrossWalks)
+        {
+            db.GisCrossWalkDefaults.Add(new GisCrossWalkDefault
+            {
+                GisCrossWalkDefaultID = crossWalkID++,
+                GisUploadSourceOrganizationID = SourceOrgID,
+                FieldDefinitionID = FieldDefinition.ProjectStage.FieldDefinitionID,
+                GisCrossWalkSourceValue = sourceValue,
+                GisCrossWalkMappedValue = mappedValue,
+            });
+        }
+
+        foreach (var (sourceValue, mappedValue) in options.LeadImplementerCrossWalks)
+        {
+            db.GisCrossWalkDefaults.Add(new GisCrossWalkDefault
+            {
+                GisCrossWalkDefaultID = crossWalkID++,
+                GisUploadSourceOrganizationID = SourceOrgID,
+                FieldDefinitionID = FieldDefinition.LeadImplementerOrganization.FieldDefinitionID,
+                GisCrossWalkSourceValue = sourceValue,
+                GisCrossWalkMappedValue = mappedValue,
+            });
+        }
+
+        db.GisUploadAttempts.Add(new GisUploadAttempt
+        {
+            GisUploadAttemptID = AttemptID,
+            GisUploadSourceOrganizationID = SourceOrgID,
+            GisUploadAttemptCreatePersonID = 1,
+            GisUploadAttemptCreateDate = new DateTime(2026, 8, 17, 0, 0, 0, DateTimeKind.Utc),
+        });
+
+        db.GisMetadataAttributes.Add(new GisMetadataAttribute { GisMetadataAttributeID = IdentifierAttrID, GisMetadataAttributeName = "project_id" });
+        db.GisMetadataAttributes.Add(new GisMetadataAttribute { GisMetadataAttributeID = NameAttrID, GisMetadataAttributeName = "project_name" });
+        db.GisMetadataAttributes.Add(new GisMetadataAttribute { GisMetadataAttributeID = StageAttrID, GisMetadataAttributeName = "status" });
+        db.GisMetadataAttributes.Add(new GisMetadataAttribute { GisMetadataAttributeID = LeadImplementerAttrID, GisMetadataAttributeName = "implementer" });
+        db.GisMetadataAttributes.Add(new GisMetadataAttribute { GisMetadataAttributeID = CompletionDateAttrID, GisMetadataAttributeName = "completed" });
+
+        db.GisFeatures.Add(new GisFeature
+        {
+            GisFeatureID = 1000,
+            GisUploadAttemptID = AttemptID,
+            GisFeatureGeometry = MakeSquare(),
+            GisImportFeatureKey = 0,
+            IsValid = true,
+        });
+
+        var metaID = 1;
+        void AddMetadata(int attributeID, string? value)
+        {
+            if (value == null) return;
+            db.GisFeatureMetadataAttributes.Add(new GisFeatureMetadataAttribute
+            {
+                GisFeatureMetadataAttributeID = metaID++,
+                GisFeatureID = 1000,
+                GisMetadataAttributeID = attributeID,
+                GisFeatureMetadataAttributeValue = value,
+            });
+        }
+
+        AddMetadata(IdentifierAttrID, "PROJ-1");
+        AddMetadata(NameAttrID, "Test Project");
+        AddMetadata(StageAttrID, options.StageValue);
+        AddMetadata(LeadImplementerAttrID, options.LeadImplementerValue);
+        AddMetadata(CompletionDateAttrID, options.CompletionDateValue);
+
+        await db.SaveChangesWithNoAuditingAsync();
+    }
+
+    /// <summary>
+    /// Adds a project already linked to <paramref name="programID"/> that the import will match on
+    /// its GIS identifier, so the update path (and the project-type derivation, which keys off
+    /// LastUpdateGisUploadAttemptID) can be exercised against pre-seeded treatments.
+    /// </summary>
+    private static async Task SeedExistingProjectAsync(
+        WADNRDbContext db, int programID, int projectTypeID, params (int TreatmentTypeID, decimal? TreatedAcres)[] treatments)
+    {
+        db.Projects.Add(new Project
+        {
+            ProjectID = ExistingProjectID,
+            ProjectName = "Existing Project",
+            FhtProjectNumber = "FHT-2026-00001",
+            ProjectGisIdentifier = "PROJ-1",
+            ProjectTypeID = projectTypeID,
+            ProjectStageID = (int)ProjectStageEnum.Implementation,
+            ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Approved,
+            ProjectLocationSimpleTypeID = (int)ProjectLocationSimpleTypeEnum.None,
+        });
+
+        db.ProjectPrograms.Add(new ProjectProgram { ProjectID = ExistingProjectID, ProgramID = programID });
+
+        var treatmentID = 1;
+        foreach (var (treatmentTypeID, treatedAcres) in treatments)
+        {
+            db.Treatments.Add(new Treatment
+            {
+                TreatmentID = treatmentID++,
+                ProjectID = ExistingProjectID,
+                TreatmentTypeID = treatmentTypeID,
+                TreatmentDetailedActivityTypeID = TreatmentDetailedActivityType.Other.TreatmentDetailedActivityTypeID,
+                TreatmentFootprintAcres = 10m,
+                TreatmentTreatedAcres = treatedAcres,
+                // Null ProjectLocationID keeps these out of the import's location/treatment cleanup.
+                ProjectLocationID = null,
+            });
+        }
+
+        await db.SaveChangesWithNoAuditingAsync();
+    }
+
+    private static GisBulkImportRequest BuildRequest() => new()
+    {
+        ProjectIdentifierMetadataAttributeID = IdentifierAttrID,
+        ProjectNameMetadataAttributeID = NameAttrID,
+        ProjectStageMetadataAttributeID = StageAttrID,
+        LeadImplementerMetadataAttributeID = LeadImplementerAttrID,
+        CompletionDateMetadataAttributeID = CompletionDateAttrID,
+    };
+
+    // ---------------------------------------------------------------------------------------
+    // 1. Project type fallback
+    // ---------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ImportProjects_FallsBackToOtherProjectType_WhenSourceOrgHasNoDefaultName()
+    {
+        // The direct WADNR-2287 regression test. "Research and Monitoring" is seeded at the lowest
+        // ProjectTypeID, so the old `ProjectTypes.First()` fallback would pick it.
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions { ProjectTypeDefaultName = null });
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsCreated);
+        var project = await db.Projects.SingleAsync();
+        Assert.AreEqual(OtherProjectTypeID, project.ProjectTypeID,
+            "A source org with no ProjectTypeDefaultName must fall back to \"Other\", not the lowest-ID project type.");
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_FallsBackToOtherProjectType_WhenDefaultNameMatchesNothing()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions { ProjectTypeDefaultName = "No Such Project Type" });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(OtherProjectTypeID, (await db.Projects.SingleAsync()).ProjectTypeID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_UsesConfiguredProjectType_WhenDefaultNameMatchesCaseInsensitively()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions { ProjectTypeDefaultName = "  commercial VEGETATION treatment " });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(CommercialProjectTypeID, (await db.Projects.SingleAsync()).ProjectTypeID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_Throws_WhenNoDefaultNameAndNoOtherProjectType()
+    {
+        // Better to fail the import than to silently publish a wrong project type.
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions { ProjectTypeDefaultName = null, IncludeOtherProjectType = false });
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest()));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 2. AdjustProjectTypeBasedOnTreatmentTypes
+    // ---------------------------------------------------------------------------------------
+
+    private static SeedOptions AdjustTypeOptions(bool adjust = true, bool? flattened = null) => new()
+    {
+        ProjectTypeDefaultName = null,
+        AdjustProjectTypeBasedOnTreatmentTypes = adjust,
+        // Skips the treatment proc, which the in-memory provider cannot run.
+        ImportAsDetailedLocationInsteadOfTreatments = true,
+        ImportIsFlattened = flattened,
+    };
+
+    [TestMethod]
+    public async Task ImportProjects_DerivesProjectTypeFromSoleTreatmentType_WhenAdjustFlagSet()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, AdjustTypeOptions());
+        await SeedExistingProjectAsync(db, ProgramID, ResearchAndMonitoringProjectTypeID,
+            (TreatmentType.NonCommercial.TreatmentTypeID, 5m),
+            (TreatmentType.NonCommercial.TreatmentTypeID, 3m));
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsUpdated);
+        Assert.AreEqual(NonCommercialProjectTypeID, (await db.Projects.SingleAsync()).ProjectTypeID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_DerivesPrescribedFireProjectType_WhenSoleTreatmentTypeIsPrescribedFire()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, AdjustTypeOptions());
+        await SeedExistingProjectAsync(db, ProgramID, ResearchAndMonitoringProjectTypeID,
+            (TreatmentType.PrescribedFire.TreatmentTypeID, 5m));
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(PrescribedFireProjectTypeID, (await db.Projects.SingleAsync()).ProjectTypeID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_LeavesProjectTypeAlone_WhenTreatmentTypesAreMixed()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, AdjustTypeOptions());
+        await SeedExistingProjectAsync(db, ProgramID, ResearchAndMonitoringProjectTypeID,
+            (TreatmentType.NonCommercial.TreatmentTypeID, 5m),
+            (TreatmentType.PrescribedFire.TreatmentTypeID, 5m));
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(ResearchAndMonitoringProjectTypeID, (await db.Projects.SingleAsync()).ProjectTypeID,
+            "A mixed treatment set is ambiguous, so the project type must be left alone.");
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_LeavesProjectTypeAlone_WhenProjectHasNoTreatments()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, AdjustTypeOptions());
+        await SeedExistingProjectAsync(db, ProgramID, ResearchAndMonitoringProjectTypeID);
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(ResearchAndMonitoringProjectTypeID, (await db.Projects.SingleAsync()).ProjectTypeID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_LeavesProjectTypeAlone_WhenAdjustFlagNotSet()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, AdjustTypeOptions(adjust: false));
+        await SeedExistingProjectAsync(db, ProgramID, ResearchAndMonitoringProjectTypeID,
+            (TreatmentType.NonCommercial.TreatmentTypeID, 5m));
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(ResearchAndMonitoringProjectTypeID, (await db.Projects.SingleAsync()).ProjectTypeID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_IgnoresZeroAcreTreatments_WhenImportIsFlattened()
+    {
+        // A flattened source writes one row per acreage column, so only the rows with treated acres
+        // describe what actually happened. Without the filter this project reads as "mixed".
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, AdjustTypeOptions(flattened: true));
+        await SeedExistingProjectAsync(db, ProgramID, ResearchAndMonitoringProjectTypeID,
+            (TreatmentType.Commercial.TreatmentTypeID, 12m),
+            (TreatmentType.PrescribedFire.TreatmentTypeID, 0m),
+            (TreatmentType.NonCommercial.TreatmentTypeID, null));
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(CommercialProjectTypeID, (await db.Projects.SingleAsync()).ProjectTypeID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_CountsZeroAcreTreatments_WhenImportIsNotFlattened()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, AdjustTypeOptions(flattened: false));
+        await SeedExistingProjectAsync(db, ProgramID, ResearchAndMonitoringProjectTypeID,
+            (TreatmentType.Commercial.TreatmentTypeID, 12m),
+            (TreatmentType.PrescribedFire.TreatmentTypeID, 0m));
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(ResearchAndMonitoringProjectTypeID, (await db.Projects.SingleAsync()).ProjectTypeID,
+            "Without the flattened flag every treatment counts, so this set is mixed and must be left alone.");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 3. DataDeriveProjectStage + ProjectStage crosswalk
+    // ---------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ImportProjects_UsesConfiguredDefaultStage_WhenDataDeriveProjectStageNotSet()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            DataDeriveProjectStage = false,
+            StageValue = "COMPLETE",
+            ProjectStageCrossWalks = { ("COMPLETE", "Completed") },
+        });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual((int)ProjectStageEnum.Implementation, (await db.Projects.SingleAsync()).ProjectStageID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_UsesCrosswalkedStage_WhenDataDeriveProjectStageSet()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            DataDeriveProjectStage = true,
+            StageValue = "complete",
+            CompletionDateValue = "2026-05-01",
+            ProjectStageCrossWalks = { ("COMPLETE", "Completed") },
+        });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(ProjectStage.Completed.ProjectStageID, (await db.Projects.SingleAsync()).ProjectStageID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_FallsBackInsteadOfThrowing_WhenStageValueHasNoCrosswalkRow()
+    {
+        // Legacy used Single(...) here and blew up the whole import on an unmapped source value.
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            DataDeriveProjectStage = true,
+            StageValue = "SOMETHING UNMAPPED",
+            CompletionDateValue = "2026-05-01",
+            ProjectStageCrossWalks = { ("COMPLETE", "Completed") },
+        });
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsCreated);
+        Assert.AreEqual((int)ProjectStageEnum.Implementation, (await db.Projects.SingleAsync()).ProjectStageID,
+            "An unmapped stage value must fall back to the configured default rather than throw.");
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_UsesPlannedStage_WhenDerivingWithNoCompletionDate()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            DataDeriveProjectStage = true,
+            StageValue = null,
+            CompletionDateValue = null,
+        });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual((int)ProjectStageEnum.Planned, (await db.Projects.SingleAsync()).ProjectStageID);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 4. LeadImplementer organization crosswalk
+    // ---------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ImportProjects_UsesCrosswalkedLeadImplementer_WhenMapped()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            LeadImplementerValue = "usfs",
+            LeadImplementerCrossWalks = { ("USFS", "Crosswalked Org") },
+        });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        var projectOrganization = await db.ProjectOrganizations.SingleAsync();
+        Assert.AreEqual(CrosswalkedOrganizationID, projectOrganization.OrganizationID);
+        Assert.AreEqual(RelationshipTypeID, projectOrganization.RelationshipTypeID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_UsesDefaultLeadImplementer_WhenValueUnmapped()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            LeadImplementerValue = "Some Other Agency",
+            LeadImplementerCrossWalks = { ("USFS", "Crosswalked Org") },
+        });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(DefaultOrganizationID, (await db.ProjectOrganizations.SingleAsync()).OrganizationID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_UsesDefaultLeadImplementer_WhenMappedOrganizationDoesNotExist()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            LeadImplementerValue = "USFS",
+            LeadImplementerCrossWalks = { ("USFS", "An Organization That Was Deleted") },
+        });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(DefaultOrganizationID, (await db.ProjectOrganizations.SingleAsync()).OrganizationID);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_UsesDefaultLeadImplementer_WhenNoCrosswalkConfigured()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions { LeadImplementerValue = "USFS" });
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(DefaultOrganizationID, (await db.ProjectOrganizations.SingleAsync()).OrganizationID);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 5. ImportAsDetailedLocationInsteadOfTreatments gates the treatment proc
+    // ---------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ImportProjects_SkipsTreatmentProc_WhenImportAsDetailedLocationInsteadOfTreatments()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions { ImportAsDetailedLocationInsteadOfTreatments = true });
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsCreated);
+        Assert.AreEqual(0, result.Warnings.Count,
+            "The treatment proc must not be called at all when the source imports detailed locations instead.");
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_CallsTreatmentProc_WhenImportAsDetailedLocationInsteadOfTreatmentsNotSet()
+    {
+        // The in-memory provider cannot run the proc, so reaching it surfaces as a warning — which
+        // is exactly the signal that the gate above is doing something.
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions { ImportAsDetailedLocationInsteadOfTreatments = false });
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsCreated);
+        Assert.AreEqual(1, result.Warnings.Count);
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_SkipsProjectTypeDerivation_WhenTreatmentImportFails()
+    {
+        // Never derive a project type from a partially imported treatment set.
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            AdjustProjectTypeBasedOnTreatmentTypes = true,
+            ImportAsDetailedLocationInsteadOfTreatments = false,
+        });
+        await SeedExistingProjectAsync(db, ProgramID, ResearchAndMonitoringProjectTypeID,
+            (TreatmentType.NonCommercial.TreatmentTypeID, 5m));
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.Warnings.Count, "Expected the in-memory treatment proc call to fail.");
+        Assert.AreEqual(ResearchAndMonitoringProjectTypeID, (await db.Projects.SingleAsync()).ProjectTypeID);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 6. GisUploadProgramMergeGrouping widens cross-program matching
+    // ---------------------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ImportProjects_MatchesProjectInSiblingProgram_WhenSourceOrgIsInAMergeGrouping()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            MergeGroupingID = MergeGroupingID,
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+        });
+        // The project lives under the sibling program, not the importing source org's program.
+        await SeedExistingProjectAsync(db, SiblingProgramID, OtherProjectTypeID);
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(0, result.ProjectsCreated, "The sibling program's project must be matched, not duplicated.");
+        Assert.AreEqual(1, result.ProjectsUpdated);
+        Assert.AreEqual(1, await db.Projects.CountAsync());
+
+        // The importing source org's program is still linked to the matched project.
+        Assert.IsTrue(await db.ProjectPrograms.AnyAsync(x => x.ProjectID == ExistingProjectID && x.ProgramID == ProgramID));
+        Assert.IsTrue(await db.ProjectPrograms.AnyAsync(x => x.ProjectID == ExistingProjectID && x.ProgramID == SiblingProgramID));
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_DoesNotMatchProjectInOtherProgram_WhenSourceOrgHasNoMergeGrouping()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions { ImportAsDetailedLocationInsteadOfTreatments = true });
+        await SeedExistingProjectAsync(db, SiblingProgramID, OtherProjectTypeID);
+
+        var result = await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        Assert.AreEqual(1, result.ProjectsCreated);
+        Assert.AreEqual(0, result.ProjectsUpdated);
+        Assert.AreEqual(2, await db.Projects.CountAsync());
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_CreatesLocationUnderImportingProgram_WhenMatchedViaMergeGrouping()
+    {
+        await using var db = NewInMemoryContext();
+        await SeedAsync(db, new SeedOptions
+        {
+            MergeGroupingID = MergeGroupingID,
+            ImportAsDetailedLocationInsteadOfTreatments = true,
+        });
+        await SeedExistingProjectAsync(db, SiblingProgramID, OtherProjectTypeID);
+
+        await GisBulkImports.ImportProjectsAsync(db, AttemptID, BuildRequest());
+
+        var location = await db.ProjectLocations.SingleAsync();
+        Assert.AreEqual(ExistingProjectID, location.ProjectID);
+        Assert.AreEqual(ProgramID, location.ProgramID,
+            "Locations belong to the importing source org's program even when the project was matched across the grouping.");
+    }
+}

--- a/WADNR.API.Tests/Integration/GisImportProjectTypeDerivationTests.cs
+++ b/WADNR.API.Tests/Integration/GisImportProjectTypeDerivationTests.cs
@@ -1,0 +1,377 @@
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO.Converters;
+using WADNR.API.Tests.Helpers;
+using WADNR.EFModels.Entities;
+using WADNR.Models.DataTransferObjects.GisBulkImport;
+
+namespace WADNR.API.Tests.Integration;
+
+/// <summary>
+/// End-to-end cover for WADNR-2287 against a real SQL Server database, configured the way
+/// DNR State Lands (ProgramID 1) is in production: no ProjectTypeDefaultName,
+/// AdjustProjectTypeBasedOnTreatmentTypes on, DataDeriveProjectStage on, and crosswalks for
+/// treatment type, project stage and lead implementer.
+///
+/// This is the piece the in-memory tests cannot reach. The project-type derivation runs only after
+/// dbo.procImportTreatmentsFromGisUploadAttempt has actually produced treatments, and the proc is
+/// also what resolves each treatment's TreatmentTypeID through the FieldDefinition 468 crosswalk.
+/// On the InMemory provider the proc call throws, so the derivation is skipped by design and any
+/// assertion about it would be vacuous.
+///
+/// The production symptom this reproduces: 442 projects created by attempts 6011 / 6015 all landed
+/// on "Research and Monitoring" — the lowest ProjectTypeID in dbo.ProjectType, which is what the old
+/// `ProjectTypes.First()` fallback selected — instead of being typed from their treatments.
+/// </summary>
+[TestClass]
+public class GisImportProjectTypeDerivationTests
+{
+    private const string OtherProjectTypeName = "Other";
+    private const string NonCommercialProjectTypeName = "Non-commercial vegetation treatment";
+    private const string PrescribedFireProjectTypeName = "Prescribed fire treatment";
+
+    // Source values invented for this fixture so they cannot collide with a real crosswalk row.
+    private const string ThinningSourceValue = "WADNR2287-THIN";
+    private const string BurnSourceValue = "WADNR2287-BURN";
+    private const string UnmappedSourceValue = "WADNR2287-UNMAPPED";
+    private const string ProjectStageSourceValue = "WADNR2287-DONE";
+    private const string LeadImplementerSourceValue = "WADNR2287-IMPLEMENTER";
+
+    private const int ThinningFeatureIdentifier = 9_200_000;
+    private const int BurnFeatureIdentifier = 9_200_001;
+    private const int UnmappedFeatureIdentifier = 9_200_002;
+
+    private int _programID;
+    private int _sourceOrganizationID;
+    private int _attemptID;
+    private int _crosswalkedOrganizationID;
+
+    [TestCleanup]
+    public async Task TearDown()
+    {
+        if (_attemptID == 0)
+        {
+            return;
+        }
+
+        await using var dbContext = NewContext();
+        await TearDownFixtureAsync(dbContext);
+        _attemptID = 0;
+    }
+
+    #region Tests
+
+    [TestMethod]
+    public async Task ImportProjects_TypesProjectsFromTheirTreatments_NotFromTheLowestIDProjectType()
+    {
+        await using var dbContext = NewContext();
+        var request = await ArrangeAsync(dbContext);
+
+        var lowestIDProjectTypeName = (await dbContext.ProjectTypes
+            .AsNoTracking().OrderBy(x => x.ProjectTypeID).FirstAsync()).ProjectTypeName;
+
+        var result = await GisBulkImports.ImportProjectsAsync(dbContext, _attemptID, request);
+
+        Assert.AreEqual(0, result.Warnings.Count,
+            $"The treatment import must succeed, or the derivation is skipped by design: {string.Join(" | ", result.Warnings)}");
+        Assert.AreEqual(3, result.ProjectsCreated);
+
+        var projectTypeNameByIdentifier = await ProjectTypeNameByGisIdentifierAsync(dbContext);
+
+        Assert.AreEqual(NonCommercialProjectTypeName, projectTypeNameByIdentifier[ThinningFeatureIdentifier.ToString()],
+            "A project whose only treatment is Non-Commercial must be typed from that treatment.");
+        Assert.AreEqual(PrescribedFireProjectTypeName, projectTypeNameByIdentifier[BurnFeatureIdentifier.ToString()],
+            "A project whose only treatment is Prescribed Fire must be typed from that treatment.");
+        Assert.AreEqual(OtherProjectTypeName, projectTypeNameByIdentifier[UnmappedFeatureIdentifier.ToString()],
+            "A project whose treatment type is Other keeps the creation fallback, which must be \"Other\".");
+
+        // The regression guard: in production the lowest ProjectTypeID is "Research and Monitoring",
+        // which is exactly what every one of these projects used to be assigned.
+        CollectionAssert.DoesNotContain(projectTypeNameByIdentifier.Values.ToList(), lowestIDProjectTypeName,
+            $"No imported project may fall back to the lowest-ID project type (\"{lowestIDProjectTypeName}\").");
+    }
+
+    [TestMethod]
+    public async Task ImportProjects_AppliesProjectStageAndLeadImplementerCrosswalks()
+    {
+        await using var dbContext = NewContext();
+        var request = await ArrangeAsync(dbContext);
+
+        var result = await GisBulkImports.ImportProjectsAsync(dbContext, _attemptID, request);
+
+        Assert.AreEqual(0, result.Warnings.Count, string.Join(" | ", result.Warnings));
+
+        var projects = await dbContext.Projects
+            .AsNoTracking()
+            .Where(p => p.CreateGisUploadAttemptID == _attemptID)
+            .Select(p => new { p.ProjectID, p.ProjectStageID })
+            .ToListAsync();
+
+        Assert.AreEqual(3, projects.Count);
+        Assert.IsTrue(projects.All(p => p.ProjectStageID == ProjectStage.Completed.ProjectStageID),
+            "DataDeriveProjectStage plus a crosswalk row mapping the source value to \"Completed\" must win " +
+            "over the source org's configured ProjectStageDefaultID (Implementation).");
+
+        var projectIDs = projects.Select(p => p.ProjectID).ToList();
+        var organizationIDs = await dbContext.ProjectOrganizations
+            .AsNoTracking()
+            .Where(x => projectIDs.Contains(x.ProjectID))
+            .Select(x => x.OrganizationID)
+            .Distinct()
+            .ToListAsync();
+
+        CollectionAssert.AreEquivalent(new[] { _crosswalkedOrganizationID }, organizationIDs,
+            "The LeadImplementer crosswalk must resolve the organization, not the source org's default.");
+    }
+
+    #endregion
+
+    #region Fixture
+
+    private static WADNRDbContext NewContext()
+    {
+        var connectionString = AssemblySteps.Configuration["sqlConnectionString"]
+            ?? throw new InvalidOperationException("sqlConnectionString not found in environment.json");
+
+        var builder = new DbContextOptionsBuilder<WADNRDbContext>()
+            .UseSqlServer(connectionString, x =>
+            {
+                x.UseNetTopologySuite();
+                x.EnableRetryOnFailure(maxRetryCount: 3, maxRetryDelay: TimeSpan.FromSeconds(5), errorNumbersToAdd: null);
+            });
+
+        return new WADNRDbContext(builder.Options, AssemblySteps.AuditUserProvider);
+    }
+
+    /// <summary>
+    /// Seeds a source organization mirroring DNR State Lands' production configuration, plus the
+    /// crosswalk rows the treatment proc and the import both read, then stages features through the
+    /// real upload path.
+    /// </summary>
+    private async Task<GisBulkImportRequest> ArrangeAsync(WADNRDbContext dbContext)
+    {
+        var program = await ProgramHelper.CreateProgramAsync(
+            dbContext, AssemblySteps.TestAdminPersonID, name: $"GIS Project Type Derivation Test {DateTime.UtcNow:yyyyMMddHHmmssfff}");
+        _programID = program.ProgramID;
+
+        var organizations = await dbContext.Organizations
+            .AsNoTracking().OrderBy(x => x.OrganizationID).Take(2)
+            .Select(x => new { x.OrganizationID, x.OrganizationName })
+            .ToListAsync();
+        Assert.AreEqual(2, organizations.Count, "This fixture needs at least two organizations to tell default from crosswalked.");
+        var defaultOrganizationID = organizations[0].OrganizationID;
+        _crosswalkedOrganizationID = organizations[1].OrganizationID;
+        var crosswalkedOrganizationName = organizations[1].OrganizationName;
+
+        var relationshipTypeID = (await dbContext.RelationshipTypes.AsNoTracking().OrderBy(x => x.RelationshipTypeID).FirstAsync()).RelationshipTypeID;
+
+        // Everything the production DNR State Lands source org (ProgramID 1) has set, which is what
+        // made it hit the bad fallback: no ProjectTypeDefaultName, derive the type from treatments.
+        var sourceOrganization = new GisUploadSourceOrganization
+        {
+            GisUploadSourceOrganizationName = $"Project Type Derivation Source {program.ProgramID}",
+            ProgramID = program.ProgramID,
+            ProjectStageDefaultID = (int)ProjectStageEnum.Implementation,
+            ProjectTypeDefaultName = null,
+            TreatmentTypeDefaultName = null,
+            DefaultLeadImplementerOrganizationID = defaultOrganizationID,
+            RelationshipTypeForDefaultOrganizationID = relationshipTypeID,
+            AdjustProjectTypeBasedOnTreatmentTypes = true,
+            DataDeriveProjectStage = true,
+            ImportAsDetailedLocationInsteadOfTreatments = false,
+            ImportAsDetailedLocationInAdditionToTreatments = false,
+            ApplyStartDateToProject = true,
+            ApplyCompletedDateToProject = true,
+            ApplyStartDateToTreatments = true,
+            ApplyEndDateToTreatments = true,
+            ImportIsFlattened = false,
+            ProjectDescriptionDefaultText = "Created by GisImportProjectTypeDerivationTests."
+        };
+        dbContext.GisUploadSourceOrganizations.Add(sourceOrganization);
+        await dbContext.SaveChangesWithNoAuditingAsync();
+        _sourceOrganizationID = sourceOrganization.GisUploadSourceOrganizationID;
+
+        // FieldDefinition 468 (TreatmentType) is read by the proc, which maps the crosswalked value
+        // onto TreatmentType.TreatmentTypeDisplayName. 36 (ProjectStage) and 535
+        // (LeadImplementerOrganization) are read by ImportProjectsAsync.
+        dbContext.GisCrossWalkDefaults.AddRange(
+            NewCrossWalk(FieldDefinition.TreatmentType.FieldDefinitionID, ThinningSourceValue, TreatmentType.NonCommercial.TreatmentTypeDisplayName),
+            NewCrossWalk(FieldDefinition.TreatmentType.FieldDefinitionID, BurnSourceValue, TreatmentType.PrescribedFire.TreatmentTypeDisplayName),
+            NewCrossWalk(FieldDefinition.ProjectStage.FieldDefinitionID, ProjectStageSourceValue, ProjectStage.Completed.ProjectStageName),
+            NewCrossWalk(FieldDefinition.LeadImplementerOrganization.FieldDefinitionID, LeadImplementerSourceValue, crosswalkedOrganizationName));
+        await dbContext.SaveChangesWithNoAuditingAsync();
+
+        var attempt = new GisUploadAttempt
+        {
+            GisUploadSourceOrganizationID = _sourceOrganizationID,
+            GisUploadAttemptCreatePersonID = AssemblySteps.TestAdminPersonID,
+            GisUploadAttemptCreateDate = new DateTime(2026, 8, 17, 0, 0, 0, DateTimeKind.Utc)
+        };
+        dbContext.GisUploadAttempts.Add(attempt);
+        await dbContext.SaveChangesWithNoAuditingAsync();
+        _attemptID = attempt.GisUploadAttemptID;
+
+        await GisBulkImports.UploadAndProcessFileAsync(dbContext, _attemptID, BuildGeoJson());
+
+        return await BuildRequestAsync(dbContext, _attemptID);
+    }
+
+    private GisCrossWalkDefault NewCrossWalk(int fieldDefinitionID, string sourceValue, string mappedValue) => new()
+    {
+        GisUploadSourceOrganizationID = _sourceOrganizationID,
+        FieldDefinitionID = fieldDefinitionID,
+        GisCrossWalkSourceValue = sourceValue,
+        GisCrossWalkMappedValue = mappedValue
+    };
+
+    /// <summary>
+    /// One feature per project: a thinning unit, a burn unit, and a unit whose treatment type has no
+    /// crosswalk row and so keeps the default treatment type.
+    /// </summary>
+    private static string BuildGeoJson()
+    {
+        var featureCollection = new FeatureCollection();
+        var factory = new GeometryFactory(new PrecisionModel(), 4326);
+
+        var features = new[]
+        {
+            (Identifier: ThinningFeatureIdentifier, TreatmentTypeValue: ThinningSourceValue),
+            (Identifier: BurnFeatureIdentifier, TreatmentTypeValue: BurnSourceValue),
+            (Identifier: UnmappedFeatureIdentifier, TreatmentTypeValue: UnmappedSourceValue),
+        };
+
+        for (var i = 0; i < features.Length; i++)
+        {
+            // Small squares inside Washington so they intersect real County / DNRUplandRegion /
+            // PriorityLandscape geometry, matching what a real upload does.
+            var minX = -122.0 + i * 0.05;
+            var minY = 46.5;
+            const double size = 0.02;
+
+            var geometry = factory.CreatePolygon(factory.CreateLinearRing(
+            [
+                new Coordinate(minX, minY),
+                new Coordinate(minX, minY + size),
+                new Coordinate(minX + size, minY + size),
+                new Coordinate(minX + size, minY),
+                new Coordinate(minX, minY)
+            ]));
+
+            featureCollection.Add(new Feature(geometry, new AttributesTable
+            {
+                { "FMA_ID", features[i].Identifier },
+                { "FMA_NM", $"PROJECT TYPE DERIVATION UNIT {i}" },
+                { "FMA_TYPE_C", features[i].TreatmentTypeValue },
+                { "TECHNIQUE_", "PCT" },
+                { "ACRES_TREA", Math.Round(12.5 + i, 2) },
+                { "PROJ_STAGE", ProjectStageSourceValue },
+                { "IMPLEMENTR", LeadImplementerSourceValue },
+                { "STAND_ORIG", IsoDate(2020, 4, 28, i) },
+                { "FMA_DT", IsoDate(2021, 5, 12, i) }
+            }));
+        }
+
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new GeoJsonConverterFactory());
+        return JsonSerializer.Serialize(featureCollection, options);
+    }
+
+    private static string IsoDate(int year, int month, int day, int index) =>
+        new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc)
+            .AddDays(index)
+            .ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
+
+    private static async Task<GisBulkImportRequest> BuildRequestAsync(WADNRDbContext dbContext, int attemptID)
+    {
+        var attributeIDByName = await dbContext.GisUploadAttemptGisMetadataAttributes
+            .AsNoTracking()
+            .Where(x => x.GisUploadAttemptID == attemptID)
+            .Select(x => new { x.GisMetadataAttributeID, x.GisMetadataAttribute.GisMetadataAttributeName })
+            .ToDictionaryAsync(x => x.GisMetadataAttributeName, x => x.GisMetadataAttributeID, StringComparer.OrdinalIgnoreCase);
+
+        int Required(string name) => attributeIDByName.TryGetValue(name, out var id)
+            ? id
+            : throw new InvalidOperationException(
+                $"Expected metadata attribute '{name}' on attempt {attemptID}. Present: {string.Join(", ", attributeIDByName.Keys)}");
+
+        return new GisBulkImportRequest
+        {
+            ProjectIdentifierMetadataAttributeID = Required("fma_id"),
+            ProjectNameMetadataAttributeID = Required("fma_nm"),
+            ProjectStageMetadataAttributeID = Required("proj_stage"),
+            LeadImplementerMetadataAttributeID = Required("implementr"),
+            StartDateMetadataAttributeID = Required("stand_orig"),
+            CompletionDateMetadataAttributeID = Required("fma_dt"),
+            TreatmentTypeMetadataAttributeID = Required("fma_type_c"),
+            TreatmentDetailedActivityTypeMetadataAttributeID = Required("technique_"),
+            FootprintAcresMetadataAttributeID = Required("acres_trea"),
+            TreatedAcresMetadataAttributeID = Required("acres_trea")
+        };
+    }
+
+    private async Task<Dictionary<string, string>> ProjectTypeNameByGisIdentifierAsync(WADNRDbContext dbContext)
+    {
+        dbContext.ChangeTracker.Clear();
+        return await dbContext.Projects
+            .AsNoTracking()
+            .Where(p => p.CreateGisUploadAttemptID == _attemptID && p.ProjectGisIdentifier != null)
+            .Select(p => new { p.ProjectGisIdentifier, p.ProjectType.ProjectTypeName })
+            .ToDictionaryAsync(x => x.ProjectGisIdentifier!, x => x.ProjectTypeName);
+    }
+
+    private async Task<List<int>> ProjectIDsForAttemptAsync(WADNRDbContext dbContext) =>
+        await dbContext.Projects
+            .AsNoTracking()
+            .Where(p => p.CreateGisUploadAttemptID == _attemptID || p.LastUpdateGisUploadAttemptID == _attemptID)
+            .Select(p => p.ProjectID)
+            .ToListAsync();
+
+    private async Task TearDownFixtureAsync(WADNRDbContext dbContext)
+    {
+        dbContext.ChangeTracker.Clear();
+
+        var projectIDs = await ProjectIDsForAttemptAsync(dbContext);
+        if (projectIDs.Count > 0)
+        {
+            await dbContext.Treatments.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectLocations.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectCounties.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectRegions.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectPriorityLandscapes.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectPrograms.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.ProjectOrganizations.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+            await dbContext.Projects.Where(x => projectIDs.Contains(x.ProjectID)).ExecuteDeleteAsync();
+        }
+
+        var featureIDsQuery = dbContext.GisFeatures
+            .Where(f => f.GisUploadAttemptID == _attemptID)
+            .Select(f => f.GisFeatureID);
+
+        await dbContext.GisFeatureMetadataAttributes.Where(x => featureIDsQuery.Contains(x.GisFeatureID)).ExecuteDeleteAsync();
+        await dbContext.GisFeatures.Where(x => x.GisUploadAttemptID == _attemptID).ExecuteDeleteAsync();
+        await dbContext.GisUploadAttemptGisMetadataAttributes.Where(x => x.GisUploadAttemptID == _attemptID).ExecuteDeleteAsync();
+        await dbContext.GisUploadAttempts.Where(x => x.GisUploadAttemptID == _attemptID).ExecuteDeleteAsync();
+
+        if (_sourceOrganizationID != 0)
+        {
+            await dbContext.GisCrossWalkDefaults
+                .Where(x => x.GisUploadSourceOrganizationID == _sourceOrganizationID).ExecuteDeleteAsync();
+            await dbContext.GisUploadSourceOrganizations
+                .Where(x => x.GisUploadSourceOrganizationID == _sourceOrganizationID).ExecuteDeleteAsync();
+        }
+
+        if (_programID != 0)
+        {
+            await dbContext.Programs.Where(x => x.ProgramID == _programID).ExecuteDeleteAsync();
+        }
+
+        // GisMetadataAttribute rows are shared global data the production code only ever adds to, so
+        // they are deliberately left alone.
+        dbContext.ChangeTracker.Clear();
+    }
+
+    #endregion
+}

--- a/WADNR.API.Tests/Integration/LoaAgolSelfHealTests.cs
+++ b/WADNR.API.Tests/Integration/LoaAgolSelfHealTests.cs
@@ -1,0 +1,191 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using WADNR.API.Services;
+using WADNR.EFModels.Entities;
+
+namespace WADNR.API.Tests.Integration;
+
+/// <summary>
+/// WADNR-2287 — exercises the real nightly LOA AGOL import against the live ArcGIS Online service.
+///
+/// This is the only way to prove the "self-healing" claim for the two LOA data gaps the rewrite
+/// created and this branch fixes:
+///
+///   * completion / planned dates, which the AGOL feed encodes as epoch milliseconds. The rewrite
+///     parsed only with DateTime.TryParse, so nightly imports resolved no dates at all — post-
+///     migration LOA projects sit at 0.8% completion-date coverage versus 65% before.
+///   * private landowners, whose creation was dropped entirely — 21.7% coverage versus 99.9%.
+///
+/// Both are applied on the *update* path, so the first nightly run after deploy should backfill
+/// them for the existing 655 projects without any data-fix script.
+///
+/// EXPLICITLY OPT-IN. It authenticates to DNR's ArcGIS Online organisation with the configured
+/// client credentials and downloads the full LOA feature set, so it is [Ignore]d by default and
+/// must never run in CI. Remove the attribute to run it deliberately, against a local restore only.
+/// </summary>
+[TestClass]
+[Ignore("Hits the live ArcGIS Online service and rewrites local LOA data. Run deliberately, never in CI.")]
+public class LoaAgolSelfHealTests
+{
+    /// <summary>Source org 3 = "DNR LOA NE" (ProgramID 3), per LoaDataImportJob.</summary>
+    private const int LoaGisUploadSourceOrganizationID = 3;
+
+    /// <summary>
+    /// Service URLs are read from the gitignored environment.json rather than hard-coded, so no
+    /// deployment endpoint lives in source control. Copy them from the deployed configmap when you
+    /// intend to run this:
+    ///
+    ///   "arcGisLoaDataEasternUrl": "...",
+    ///   "arcGisLoaDataWesternUrl": "..."
+    ///
+    /// LoaDataImportJob imports Eastern then Western against the same source organization, so
+    /// running only one leaves the other cohort untouched.
+    /// </summary>
+    private const string EasternUrlKey = "arcGisLoaDataEasternUrl";
+    private const string WesternUrlKey = "arcGisLoaDataWesternUrl";
+
+    private static string RequireUrl(string key) =>
+        AssemblySteps.Configuration[key] is { Length: > 0 } url
+            ? url
+            : throw new InvalidOperationException(
+                $"'{key}' is not set in WADNR.API.Tests/environment.json. Copy it from the deployed " +
+                "configmap to run this test deliberately.");
+
+    [TestMethod]
+    public async Task LoaImport_BackfillsDatesAndLandowners_OnExistingProjects()
+    {
+        var before = await MeasureAsync();
+        Console.WriteLine($"BEFORE  projects={before.Projects}  withCompletionDate={before.WithCompletionDate}  " +
+                          $"withPlannedDate={before.WithPlannedDate}  withLandowner={before.WithLandowner}");
+
+        await RunEasternImportAsync();
+
+        var after = await MeasureAsync();
+        Console.WriteLine($"AFTER   projects={after.Projects}  withCompletionDate={after.WithCompletionDate}  " +
+                          $"withPlannedDate={after.WithPlannedDate}  withLandowner={after.WithLandowner}");
+
+        Assert.IsTrue(after.WithCompletionDate > before.WithCompletionDate,
+            "Completion dates must backfill — this is the epoch-millisecond parsing fix on the update path.");
+        Assert.IsTrue(after.WithLandowner > before.WithLandowner,
+            "Landowner records must backfill — this is the restored MakeProjectPeopleAndSave on the update path.");
+    }
+
+    [TestMethod]
+    public async Task LoaWesternImport_BackfillsRemainingDates()
+    {
+        var before = await MeasureAsync();
+        Console.WriteLine($"BEFORE  projects={before.Projects}  withCompletionDate={before.WithCompletionDate}  " +
+                          $"withPlannedDate={before.WithPlannedDate}  withLandowner={before.WithLandowner}");
+
+        await RunImportAsync(RequireUrl(WesternUrlKey));
+
+        var after = await MeasureAsync();
+        Console.WriteLine($"AFTER   projects={after.Projects}  withCompletionDate={after.WithCompletionDate}  " +
+                          $"withPlannedDate={after.WithPlannedDate}  withLandowner={after.WithLandowner}");
+    }
+
+    /// <summary>Esri's public OAuth token endpoint; overridable via environment.json.</summary>
+    private static string ArcGisAuthUrl =>
+        AssemblySteps.Configuration["arcGisAuthUrl"] is { Length: > 0 } url
+            ? url
+            : "https://www.arcgis.com/sharing/rest/oauth2/token";
+
+    /// <summary>
+    /// Builds just enough WADNRConfiguration for ArcGisAuthService, reading the client credentials
+    /// from the API's appsecrets.json. The service URLs live in the deployed configmaps rather than
+    /// local config, so they are constants here.
+    /// </summary>
+    private static WADNRConfiguration BuildConfiguration()
+    {
+        var secretsPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "WADNR.API", "appsecrets.json"));
+        Assert.IsTrue(File.Exists(secretsPath), $"Expected API secrets at {secretsPath}");
+
+        using var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(secretsPath));
+        string Read(string key) => doc.RootElement.TryGetProperty(key, out var v) ? v.GetString() ?? "" : "";
+
+        var clientId = Read("ArcGisClientId");
+        var clientSecret = Read("ArcGisClientSecret");
+        Assert.IsFalse(string.IsNullOrWhiteSpace(clientId), "ArcGisClientId is not configured in appsecrets.json.");
+        Assert.IsFalse(string.IsNullOrWhiteSpace(clientSecret), "ArcGisClientSecret is not configured in appsecrets.json.");
+
+        return new WADNRConfiguration
+        {
+            ArcGisAuthUrl = ArcGisAuthUrl,
+            ArcGisClientId = clientId,
+            ArcGisClientSecret = clientSecret
+        };
+    }
+
+    private static Task RunEasternImportAsync() => RunImportAsync(RequireUrl(EasternUrlKey));
+
+    private static async Task RunImportAsync(string arcOnlineUrl)
+    {
+        var configuration = Options.Create(BuildConfiguration());
+        var httpClientFactory = new SimpleHttpClientFactory();
+
+        var authService = new ArcGisAuthService(httpClientFactory, configuration);
+        var accessToken = await authService.GetApplicationAccessTokenAsync();
+        Assert.IsFalse(string.IsNullOrEmpty(accessToken), "Failed to obtain an ArcGIS application access token.");
+
+        await using var dbContext = NewContext();
+        var importService = new GisDataImportService(
+            httpClientFactory, dbContext, NullLogger<GisDataImportService>.Instance);
+
+        await importService.DownloadAndImportFeaturesWithGetAsync(
+            arcOnlineUrl, LoaGisUploadSourceOrganizationID, accessToken);
+    }
+
+    private sealed record Coverage(int Projects, int WithCompletionDate, int WithPlannedDate, int WithLandowner);
+
+    /// <summary>
+    /// Coverage across LOA projects created by a GIS upload since the migration cutover — the 655
+    /// the rewrite left incomplete.
+    /// </summary>
+    private static async Task<Coverage> MeasureAsync()
+    {
+        await using var dbContext = NewContext();
+
+        var projects = await dbContext.Projects
+            .AsNoTracking()
+            .Where(p => p.CreateGisUploadAttempt != null
+                && p.CreateGisUploadAttempt.GisUploadSourceOrganization.ProgramID == 3
+                && p.CreateGisUploadAttempt.GisUploadAttemptCreateDate >= new DateTime(2026, 3, 1))
+            .Select(p => new
+            {
+                p.ProjectID,
+                HasCompletion = p.CompletionDate != null,
+                HasPlanned = p.PlannedDate != null,
+                HasLandowner = p.ProjectPeople.Any(x => x.ProjectPersonRelationshipTypeID
+                    == ProjectPersonRelationshipType.PrivateLandowner.ProjectPersonRelationshipTypeID)
+            })
+            .ToListAsync();
+
+        return new Coverage(
+            projects.Count,
+            projects.Count(x => x.HasCompletion),
+            projects.Count(x => x.HasPlanned),
+            projects.Count(x => x.HasLandowner));
+    }
+
+    private static WADNRDbContext NewContext()
+    {
+        var connectionString = AssemblySteps.Configuration["sqlConnectionString"]
+            ?? throw new InvalidOperationException("sqlConnectionString not found in environment.json");
+
+        var builder = new DbContextOptionsBuilder<WADNRDbContext>()
+            .UseSqlServer(connectionString, x =>
+            {
+                x.UseNetTopologySuite();
+                x.EnableRetryOnFailure(maxRetryCount: 3, maxRetryDelay: TimeSpan.FromSeconds(5), errorNumbersToAdd: null);
+            });
+
+        return new WADNRDbContext(builder.Options, AssemblySteps.AuditUserProvider);
+    }
+
+    private sealed class SimpleHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new() { Timeout = TimeSpan.FromMinutes(10) };
+    }
+}

--- a/WADNR.API.Tests/environment.json.template
+++ b/WADNR.API.Tests/environment.json.template
@@ -1,5 +1,9 @@
 {
   "sqlConnectionString": "<YOUR_SQL_SERVER_CONNECTION_STRING>",
   "testAdminPersonID": "<PERSON_ID_WITH_ADMIN_ROLE>",
-  "testNormalPersonID": "<PERSON_ID_WITH_NORMAL_ROLE>"
+  "testNormalPersonID": "<PERSON_ID_WITH_NORMAL_ROLE>",
+
+  "//": "Only needed to run the [Ignore]d LoaAgolSelfHealTests deliberately. Copy the service URLs from the deployed configmap; they are intentionally not committed.",
+  "arcGisLoaDataEasternUrl": "<LOA_EASTERN_FEATURE_SERVICE_QUERY_URL>",
+  "arcGisLoaDataWesternUrl": "<LOA_WESTERN_FEATURE_SERVICE_QUERY_URL>"
 }

--- a/WADNR.Database/Scripts/ReleaseScripts/0009 - WADNR-2287 Correct project types on GIS bulk imported projects.sql
+++ b/WADNR.Database/Scripts/ReleaseScripts/0009 - WADNR-2287 Correct project types on GIS bulk imported projects.sql
@@ -1,0 +1,149 @@
+DECLARE @MigrationName VARCHAR(200);
+SET @MigrationName = '0009 - WADNR-2287 Correct project types on GIS bulk imported projects'
+
+IF NOT EXISTS(SELECT * FROM dbo.DatabaseMigration DM WHERE DM.ReleaseScriptFileName = @MigrationName)
+BEGIN
+    PRINT @MigrationName;
+
+    -- WADNR-2287: GisBulkImports.ImportProjectsAsync assigned newly-created projects the *first*
+    -- row of dbo.ProjectType when the source organization had no matching ProjectTypeDefaultName.
+    -- With no ORDER BY that is the lowest ProjectTypeID, which in production is
+    -- "Research and Monitoring". It also never honoured the source organization's
+    -- AdjustProjectTypeBasedOnTreatmentTypes flag, which legacy applied after the treatment import.
+    --
+    -- DNR State Lands (ProgramID 1) has ProjectTypeDefaultName NULL and
+    -- AdjustProjectTypeBasedOnTreatmentTypes = 1, so every project it created hit the bad fallback.
+    -- In production this is 442 projects, all created by GisUploadAttempt 6011 and 6015 (2026-07-02).
+    --
+    -- Both scoping predicates are kept deliberately:
+    --   * CreateGisUploadAttemptID IN (6011, 6015) — the damage originates at *creation* time; the
+    --     update path never wrote ProjectTypeID, which is why later attempts (6124, 6159) re-touched
+    --     these projects and left the wrong type in place.
+    --   * ProjectTypeID = "Research and Monitoring" — makes this a no-op for anything corrected by
+    --     hand (or by a re-upload) between now and deployment. No human-set "Research and
+    --     Monitoring" project existed anywhere in production when this was scoped.
+    --
+    -- Project types are resolved BY NAME, never by ID: dbo.ProjectType is user-managed data rather
+    -- than a seeded lookup, so the IDs differ between production, QA and dev.
+
+    DECLARE @ResearchAndMonitoringProjectTypeID INT;
+    DECLARE @CommercialProjectTypeID INT;
+    DECLARE @NonCommercialProjectTypeID INT;
+    DECLARE @PrescribedFireProjectTypeID INT;
+    DECLARE @OtherProjectTypeID INT;
+
+    SELECT @ResearchAndMonitoringProjectTypeID = ProjectTypeID FROM dbo.ProjectType WHERE LTRIM(RTRIM(ProjectTypeName)) = 'Research and Monitoring';
+    SELECT @CommercialProjectTypeID           = ProjectTypeID FROM dbo.ProjectType WHERE LTRIM(RTRIM(ProjectTypeName)) = 'Commercial vegetation treatment';
+    SELECT @NonCommercialProjectTypeID        = ProjectTypeID FROM dbo.ProjectType WHERE LTRIM(RTRIM(ProjectTypeName)) = 'Non-commercial vegetation treatment';
+    SELECT @PrescribedFireProjectTypeID       = ProjectTypeID FROM dbo.ProjectType WHERE LTRIM(RTRIM(ProjectTypeName)) = 'Prescribed fire treatment';
+    SELECT @OtherProjectTypeID                = ProjectTypeID FROM dbo.ProjectType WHERE LTRIM(RTRIM(ProjectTypeName)) = 'Other';
+
+    DECLARE @CommercialTreatmentTypeID     INT = (SELECT TreatmentTypeID FROM dbo.TreatmentType WHERE TreatmentTypeName = 'Commercial');
+    DECLARE @NonCommercialTreatmentTypeID  INT = (SELECT TreatmentTypeID FROM dbo.TreatmentType WHERE TreatmentTypeName = 'NonCommercial');
+    DECLARE @PrescribedFireTreatmentTypeID INT = (SELECT TreatmentTypeID FROM dbo.TreatmentType WHERE TreatmentTypeName = 'PrescribedFire');
+
+    IF @ResearchAndMonitoringProjectTypeID IS NULL OR @OtherProjectTypeID IS NULL
+    BEGIN
+        -- Nothing to repair here (or the environment lacks the project types this keys off).
+        PRINT 'Skipping: could not resolve the "Research and Monitoring" and/or "Other" project types by name.';
+    END
+    ELSE
+    BEGIN
+        -- Projects created by the two bad attempts that are still on the wrong type, carrying the
+        -- source organization's ImportIsFlattened flag so the treatment filter matches the runtime
+        -- rule in GisBulkImports.ApplyProjectTypeFromTreatmentTypesAsync.
+        DECLARE @AffectedProject TABLE (ProjectID INT PRIMARY KEY, ImportIsFlattened BIT NOT NULL);
+
+        INSERT INTO @AffectedProject (ProjectID, ImportIsFlattened)
+        SELECT P.ProjectID,
+               CASE WHEN GUSO.ImportIsFlattened = 1 THEN 1 ELSE 0 END
+        FROM dbo.Project P
+        INNER JOIN dbo.GisUploadAttempt GUA ON GUA.GisUploadAttemptID = P.CreateGisUploadAttemptID
+        INNER JOIN dbo.GisUploadSourceOrganization GUSO ON GUSO.GisUploadSourceOrganizationID = GUA.GisUploadSourceOrganizationID
+        WHERE P.CreateGisUploadAttemptID IN (6011, 6015)
+          AND P.ProjectTypeID = @ResearchAndMonitoringProjectTypeID;
+
+        DECLARE @AffectedProjectCount INT = (SELECT COUNT(*) FROM @AffectedProject);
+        PRINT 'Found ' + CAST(@AffectedProjectCount AS VARCHAR(10)) + ' project(s) to re-type.';
+
+        -- Each project's sole treatment type, if it has exactly one. Projects with a mixed or empty
+        -- treatment set get no row here and fall through to "Other" (the legacy default) below.
+        DECLARE @SoleTreatmentType TABLE (ProjectID INT PRIMARY KEY, TreatmentTypeID INT NOT NULL);
+
+        INSERT INTO @SoleTreatmentType (ProjectID, TreatmentTypeID)
+        SELECT T.ProjectID, MIN(T.TreatmentTypeID)
+        FROM dbo.Treatment T
+        INNER JOIN @AffectedProject AP ON AP.ProjectID = T.ProjectID
+        WHERE AP.ImportIsFlattened = 0
+           OR ISNULL(T.TreatmentTreatedAcres, 0) > 0
+        GROUP BY T.ProjectID
+        HAVING COUNT(DISTINCT T.TreatmentTypeID) = 1;
+
+        UPDATE P
+        SET ProjectTypeID =
+            COALESCE(
+                CASE
+                    WHEN STT.TreatmentTypeID = @CommercialTreatmentTypeID     THEN @CommercialProjectTypeID
+                    WHEN STT.TreatmentTypeID = @NonCommercialTreatmentTypeID  THEN @NonCommercialProjectTypeID
+                    WHEN STT.TreatmentTypeID = @PrescribedFireTreatmentTypeID THEN @PrescribedFireProjectTypeID
+                END,
+                -- No treatments, a mixed treatment set, an "Other" treatment type, or a target
+                -- project type that doesn't exist in this environment: fall back the way legacy did.
+                @OtherProjectTypeID)
+        FROM dbo.Project P
+        INNER JOIN @AffectedProject AP ON AP.ProjectID = P.ProjectID
+        LEFT JOIN @SoleTreatmentType STT ON STT.ProjectID = P.ProjectID;
+
+        DECLARE @ReTypedCount INT = @@ROWCOUNT;
+        PRINT 'Re-typed ' + CAST(@ReTypedCount AS VARCHAR(10)) + ' project(s).';
+    END
+
+    /*
+        Part 2 - backfill DNR Service Forestry Regional Coordinators.
+
+        The rewrite also dropped legacy's AddProjectCoordinators, so Landowner Assistance projects
+        created by a GIS upload since the migration never got the coordinator for the DNR Upland
+        Region they landed in. Restoring the code fixes this going forward, but only for *newly
+        created* projects — which is what legacy did, and deliberately so: assigning on the update
+        path would silently re-add a coordinator a steward had removed, on every nightly run.
+
+        That leaves the existing projects needing a one-time backfill, which is this.
+
+        Scoped to Landowner Assistance projects created by a GIS upload on or after 2026-03-01 (the
+        migration cutover) whose region has a coordinator and which have no coordinator record.
+        Idempotent via NOT EXISTS, so it is safe alongside any nightly run that lands first.
+    */
+    DECLARE @LandownerAssistanceProgramID INT = 3;
+    DECLARE @CoordinatorRelationshipTypeID INT =
+        (SELECT ProjectPersonRelationshipTypeID FROM dbo.ProjectPersonRelationshipType
+         WHERE ProjectPersonRelationshipTypeName = 'ServiceForestryRegionalCoordinator');
+
+    IF @CoordinatorRelationshipTypeID IS NULL
+    BEGIN
+        PRINT 'Skipping coordinator backfill: ServiceForestryRegionalCoordinator relationship type not found.';
+    END
+    ELSE
+    BEGIN
+        INSERT INTO dbo.ProjectPerson (ProjectID, PersonID, ProjectPersonRelationshipTypeID, CreatedAsPartOfBulkImport)
+        SELECT DISTINCT P.ProjectID, R.DNRUplandRegionCoordinatorID, @CoordinatorRelationshipTypeID, 1
+        FROM dbo.Project P
+        INNER JOIN dbo.GisUploadAttempt A ON A.GisUploadAttemptID = P.CreateGisUploadAttemptID
+        INNER JOIN dbo.GisUploadSourceOrganization G ON G.GisUploadSourceOrganizationID = A.GisUploadSourceOrganizationID
+        INNER JOIN dbo.ProjectProgram PP ON PP.ProjectID = P.ProjectID AND PP.ProgramID = @LandownerAssistanceProgramID
+        INNER JOIN dbo.ProjectRegion PR ON PR.ProjectID = P.ProjectID
+        INNER JOIN dbo.DNRUplandRegion R ON R.DNRUplandRegionID = PR.DNRUplandRegionID
+        WHERE A.GisUploadAttemptCreateDate >= '2026-03-01'
+          AND R.DNRUplandRegionCoordinatorID IS NOT NULL
+          AND NOT EXISTS (
+                SELECT 1 FROM dbo.ProjectPerson EX
+                WHERE EX.ProjectID = P.ProjectID
+                  AND EX.PersonID = R.DNRUplandRegionCoordinatorID
+                  AND EX.ProjectPersonRelationshipTypeID = @CoordinatorRelationshipTypeID);
+
+        DECLARE @CoordinatorsAdded INT = @@ROWCOUNT;
+        PRINT 'Backfilled ' + CAST(@CoordinatorsAdded AS VARCHAR(10)) + ' regional coordinator record(s).';
+    END
+
+    INSERT INTO dbo.DatabaseMigration(MigrationAuthorName, ReleaseScriptFileName, MigrationReason)
+    SELECT 'mpeters', @MigrationName, 'WADNR-2287 - correct project types on projects the GIS bulk import mis-typed as "Research and Monitoring"'
+END

--- a/WADNR.Database/Scripts/ReleaseScripts/0009 - WADNR-2287 Correct project types on GIS bulk imported projects.sql
+++ b/WADNR.Database/Scripts/ReleaseScripts/0009 - WADNR-2287 Correct project types on GIS bulk imported projects.sql
@@ -52,14 +52,28 @@ BEGIN
         -- Projects created by the two bad attempts that are still on the wrong type, carrying the
         -- source organization's ImportIsFlattened flag so the treatment filter matches the runtime
         -- rule in GisBulkImports.ApplyProjectTypeFromTreatmentTypesAsync.
-        DECLARE @AffectedProject TABLE (ProjectID INT PRIMARY KEY, ImportIsFlattened BIT NOT NULL);
+        DECLARE @AffectedProject TABLE (
+            ProjectID INT PRIMARY KEY,
+            ImportIsFlattened BIT NOT NULL,
+            FallbackProjectTypeID INT NOT NULL);
 
-        INSERT INTO @AffectedProject (ProjectID, ImportIsFlattened)
+        /*
+            FallbackProjectTypeID is what the corrected importer would assign at creation time:
+            the source organization's configured ProjectTypeDefaultName, or "Other" when it has none
+            or names a type that does not exist. Carrying it per project keeps this script's
+            behaviour identical to GisBulkImports.ResolveDefaultProjectTypeIDAsync rather than
+            assuming every affected project should fall back to "Other" -- which happens to be true
+            for DNR State Lands, but only because it has no default configured.
+        */
+        INSERT INTO @AffectedProject (ProjectID, ImportIsFlattened, FallbackProjectTypeID)
         SELECT P.ProjectID,
-               CASE WHEN GUSO.ImportIsFlattened = 1 THEN 1 ELSE 0 END
+               CASE WHEN GUSO.ImportIsFlattened = 1 THEN 1 ELSE 0 END,
+               ISNULL(DEF.ProjectTypeID, @OtherProjectTypeID)
         FROM dbo.Project P
         INNER JOIN dbo.GisUploadAttempt GUA ON GUA.GisUploadAttemptID = P.CreateGisUploadAttemptID
         INNER JOIN dbo.GisUploadSourceOrganization GUSO ON GUSO.GisUploadSourceOrganizationID = GUA.GisUploadSourceOrganizationID
+        LEFT JOIN dbo.ProjectType DEF
+               ON LTRIM(RTRIM(DEF.ProjectTypeName)) = LTRIM(RTRIM(GUSO.ProjectTypeDefaultName))
         WHERE P.CreateGisUploadAttemptID IN (6011, 6015)
           AND P.ProjectTypeID = @ResearchAndMonitoringProjectTypeID;
 
@@ -67,7 +81,7 @@ BEGIN
         PRINT 'Found ' + CAST(@AffectedProjectCount AS VARCHAR(10)) + ' project(s) to re-type.';
 
         -- Each project's sole treatment type, if it has exactly one. Projects with a mixed or empty
-        -- treatment set get no row here and fall through to "Other" (the legacy default) below.
+        -- treatment set get no row here and fall through to FallbackProjectTypeID below.
         DECLARE @SoleTreatmentType TABLE (ProjectID INT PRIMARY KEY, TreatmentTypeID INT NOT NULL);
 
         INSERT INTO @SoleTreatmentType (ProjectID, TreatmentTypeID)
@@ -88,8 +102,11 @@ BEGIN
                     WHEN STT.TreatmentTypeID = @PrescribedFireTreatmentTypeID THEN @PrescribedFireProjectTypeID
                 END,
                 -- No treatments, a mixed treatment set, an "Other" treatment type, or a target
-                -- project type that doesn't exist in this environment: fall back the way legacy did.
-                @OtherProjectTypeID)
+                -- project type that doesn't exist in this environment: fall back to whatever the
+                -- corrected creation path would have assigned. This mirrors the runtime rule, which
+                -- only re-types a project when its treatments share exactly one type and otherwise
+                -- leaves the creation-time value in place.
+                AP.FallbackProjectTypeID)
         FROM dbo.Project P
         INNER JOIN @AffectedProject AP ON AP.ProjectID = P.ProjectID
         LEFT JOIN @SoleTreatmentType STT ON STT.ProjectID = P.ProjectID;

--- a/WADNR.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
+++ b/WADNR.Database/Scripts/ReleaseScripts/Script.PostDeployment.ReleaseScripts.sql
@@ -24,4 +24,6 @@ GO
 GO
 :r ".\0008 - WADNR-2264 Delete blocked projects imported in error.sql"
 GO
+:r ".\0009 - WADNR-2287 Correct project types on GIS bulk imported projects.sql"
+GO
 

--- a/WADNR.Database/WADNR.Database.sqlproj
+++ b/WADNR.Database/WADNR.Database.sqlproj
@@ -430,6 +430,7 @@
     <None Include="Scripts\ReleaseScripts\0006 - Add ApiKeyGeneratedDate to Person.sql" />
     <None Include="Scripts\ReleaseScripts\0007 - WADNR-2263 Backfill FHT Project Numbers with year prefix.sql" />
     <None Include="Scripts\ReleaseScripts\0008 - WADNR-2264 Delete blocked projects imported in error.sql" />
+    <None Include="Scripts\ReleaseScripts\0009 - WADNR-2287 Correct project types on GIS bulk imported projects.sql" />
   </ItemGroup>
   <UsingTask TaskName="ScriptDeploymentGenerator" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
     <ParameterGroup>

--- a/WADNR.EFModels/Entities/GisBulkImport.StaticHelpers.cs
+++ b/WADNR.EFModels/Entities/GisBulkImport.StaticHelpers.cs
@@ -147,7 +147,11 @@ public static class GisBulkImports
 
         foreach (var feature in featureCollection)
         {
-            if (feature.Geometry == null) continue;
+            // Only areal geometry is usable: every downstream consumer treats a ProjectLocation as a
+            // project *area* (acreage, treatment footprints, region/county intersection). Legacy
+            // filtered to Polygon / MultiPolygon in IsUsableFeatureGeoJson; the rewrite only skipped
+            // null geometry, so a point or line feature would have produced a zero-acre location.
+            if (!IsUsableGeometry(feature.Geometry)) continue;
 
             feature.Geometry.SRID = 4326;
 
@@ -406,6 +410,22 @@ public static class GisBulkImports
         int? objectIdAttributeID = metadataAttributeIDByName.TryGetValue("objectid", out var oidAttrID) ? oidAttrID : null;
         int? globalIdAttributeID = metadataAttributeIDByName.TryGetValue("globalid", out var gidAttrID) ? gidAttrID : null;
 
+        // Apply the source org's include/exclude column configuration before anything else looks at
+        // the features, matching legacy's FilterListBasedOnIncludeExcludeCriteria. The rewrite loaded
+        // this configuration and then never read it, so every program's whitelist/blacklist was inert
+        // — DNR State Lands has a blacklist on technique_cd that was being ignored entirely.
+        var featureCountBeforeFiltering = features.Count;
+        features = ApplyExcludeIncludeFilters(features, sourceOrg, metadataAttributeIDByName, featureMetadata);
+        var featuresExcluded = featureCountBeforeFiltering - features.Count;
+        if (featuresExcluded > 0)
+        {
+            // Surfaced rather than dropped silently: an admin comparing the source GDB's feature
+            // count against what landed needs to know the difference was deliberate.
+            result.Warnings.Add(
+                $"Excluded {featuresExcluded} of {featureCountBeforeFiltering} features per this program's " +
+                $"GIS include/exclude column configuration.");
+        }
+
         // Get project identifier values to group features by project
         // Normalize to uppercase for case-insensitive grouping; keep originals for display/storage
         var projectIdentifierLookup = new Dictionary<int, string>();
@@ -431,6 +451,56 @@ public static class GisBulkImports
         // on either ProjectGisIdentifier or ProjectName, matching the normalization the
         // import loop already applies at line ~400.
         var (blockedIdentifiers, blockedNames) = await LoadBlockListAsync(dbContext, sourceOrg.ProgramID);
+
+        // Block-list entries can also point straight at a ProjectID. Legacy honoured that; the
+        // rewrite only matched on identifier/name, so an entry created by picking an existing
+        // project did nothing.
+        var blockedProjectIDs = await dbContext.ProjectImportBlockLists
+            .AsNoTracking()
+            .Where(x => x.ProgramID == sourceOrg.ProgramID && x.ProjectID != null)
+            .Select(x => x.ProjectID!.Value)
+            .ToHashSetAsync();
+
+        // Private landowners imported from GIS metadata. Only pay for the Person list when the
+        // Landowner column is actually mapped.
+        //
+        // Primary contact is deliberately not handled here. Legacy resolved it against
+        // FieldDefinition.ProjectPrimaryContact (252), while the only GisDefaultMapping row that
+        // exists is on FieldDefinition.PrimaryContact (275) — so it never imported on any legacy
+        // path, and wiring it up now would be a new feature rather than restored parity.
+        var importsPeople = request.PrivateLandownerMetadataAttributeID.HasValue;
+        var personLookup = importsPeople ? await LoadPersonLookupAsync(dbContext) : null;
+
+        // Legacy skipped a project outright when the program's default stage is Completed, the stage
+        // isn't derived from the data, and the feature carries no completion date
+        // (GisUploadSourceOrganization.RequiresCompletionDate). The rewrite imported it anyway.
+        var requiresCompletionDate = sourceOrg.ProjectStageDefaultID == ProjectStage.Completed.ProjectStageID
+            && !sourceOrg.DataDeriveProjectStage;
+        var projectsSkippedForMissingCompletionDate = 0;
+
+        // Default project type for newly-created projects. Resolved once — it doesn't vary per
+        // project — and falling back to "Other" rather than an arbitrary row (WADNR-2287).
+        var defaultProjectTypeID = await ResolveDefaultProjectTypeIDAsync(dbContext, sourceOrg);
+
+        // Programs whose projects are candidates for matching an incoming GIS identifier. Normally
+        // just this source org's program, but when the org belongs to a merge grouping (the USFS
+        // sources) a project already created by a sibling program must be matched and updated
+        // rather than duplicated. The program link and ProjectLocation.ProgramID below still use
+        // sourceOrg.ProgramID.
+        var matchProgramIDs = await ResolveMatchProgramIDsAsync(dbContext, sourceOrg);
+
+        // Crosswalks configured on this source org, used to map raw GIS values onto FHT lookups.
+        var projectStageCrossWalks = sourceOrg.GisCrossWalkDefaults
+            .Where(x => x.FieldDefinitionID == FieldDefinition.ProjectStage.FieldDefinitionID)
+            .ToList();
+        var leadImplementerCrossWalks = sourceOrg.GisCrossWalkDefaults
+            .Where(x => x.FieldDefinitionID == FieldDefinition.LeadImplementerOrganization.FieldDefinitionID)
+            .ToList();
+
+        // Only pay for the organization list when a LeadImplementer crosswalk is actually configured.
+        var organizationIDByName = leadImplementerCrossWalks.Count > 0
+            ? await LoadOrganizationIDsByNameAsync(dbContext)
+            : new Dictionary<string, int>(StringComparer.InvariantCultureIgnoreCase);
 
         foreach (var projectGroup in featuresByProject)
         {
@@ -459,11 +529,54 @@ public static class GisBulkImports
                 continue;
             }
 
+            // Project stage: the source org's configured default unless it is set to derive the
+            // stage from the GIS data, in which case the raw value is run through the ProjectStage
+            // crosswalk (WADNR-2287 — this was dropped in the rewrite and the default always won).
+            var projectStageSourceValue = FirstNonEmptyMetadataValue(
+                projectGroup, featureMetadata, request.ProjectStageMetadataAttributeID);
+
+            // Dates are resolved across every feature in the project (earliest start, latest
+            // completion) and understand ArcGIS Online's epoch-millisecond encoding — see
+            // ResolveDateFromFeatures. The rewrite parsed only the first feature and only with
+            // DateTime.TryParse, so nightly AGOL imports resolved no dates at all.
+            var featureStartDate = ResolveDateFromFeatures(
+                projectGroup, featureMetadata, request.StartDateMetadataAttributeID, useEarliest: true);
+            var featureCompletionDate = ResolveDateFromFeatures(
+                projectGroup, featureMetadata, request.CompletionDateMetadataAttributeID, useEarliest: false);
+            var hasCompletionDate = featureCompletionDate.HasValue;
+            var projectStageID = DeriveProjectStageID(
+                sourceOrg, projectStageCrossWalks, projectStageSourceValue, hasCompletionDate);
+
+            // A program whose projects are Completed by definition can't import one with no
+            // completion date — legacy dropped these rather than creating a bad record.
+            if (requiresCompletionDate && !hasCompletionDate)
+            {
+                projectsSkippedForMissingCompletionDate++;
+                continue;
+            }
+
+            // Landowner values carried on the features, gathered across the whole project group the
+            // way legacy did (distinct, non-empty, in feature order).
+            var landownerValues = importsPeople
+                ? DistinctMetadataValues(projectGroup, featureMetadata, request.PrivateLandownerMetadataAttributeID)
+                : new List<string>();
+
+            // Lead implementer: crosswalk the raw value onto an Organization, falling back to the
+            // source org's configured default when unmapped or unrecognized.
+            var leadImplementerSourceValue = FirstNonEmptyMetadataValue(
+                projectGroup, featureMetadata, request.LeadImplementerMetadataAttributeID);
+            var leadImplementerOrganizationID = ResolveLeadImplementerOrganizationID(
+                sourceOrg, leadImplementerCrossWalks, organizationIDByName, leadImplementerSourceValue);
+
             // Per-iteration outcomes — applied to `result` only after the transaction commits,
             // so deadlock-triggered retries don't double-count.
             var wasCreated = false;
             var wasUpdated = false;
+            var wasBlockedByProjectID = false;
             var locationsCreatedThisIteration = 0;
+            // People created inside this iteration's transaction. Held back from the shared
+            // personLookup until the transaction commits — see ApplyProjectLandownersAsync.
+            var peopleCreatedThisIteration = new List<(int PersonID, string FirstName, string LastName, DateTime CreateDate)>();
             GisBulkImportProjectResult resultEntry = null;
 
             var strategy = dbContext.Database.CreateExecutionStrategy();
@@ -473,46 +586,62 @@ public static class GisBulkImports
                 dbContext.ChangeTracker.Clear();
                 wasCreated = false;
                 wasUpdated = false;
+                wasBlockedByProjectID = false;
                 locationsCreatedThisIteration = 0;
+                peopleCreatedThisIteration.Clear();
                 resultEntry = null;
 
                 await using var transaction = await dbContext.Database.BeginTransactionAsync();
 
-                // Find existing project by GIS identifier within the same program (case-insensitive)
+                // Find existing project by GIS identifier within the matching program(s) (case-insensitive)
                 var existingProject = await dbContext.Projects
                     .Include(p => p.ProjectPrograms)
                     .FirstOrDefaultAsync(p => p.ProjectGisIdentifier != null &&
                         p.ProjectGisIdentifier.Trim().ToUpper() == projectIdentifier &&
-                        p.ProjectPrograms.Any(pp => pp.ProgramID == sourceOrg.ProgramID));
+                        p.ProjectPrograms.Any(pp => matchProgramIDs.Contains(pp.ProgramID)));
+
+                if (existingProject != null && blockedProjectIDs.Contains(existingProject.ProjectID))
+                {
+                    // Block-list entry pointing at this exact project — skip create and update alike.
+                    wasBlockedByProjectID = true;
+                    resultEntry = new GisBulkImportProjectResult
+                    {
+                        ProjectID = existingProject.ProjectID,
+                        ProjectName = existingProject.ProjectName
+                    };
+                    await transaction.RollbackAsync();
+                    return;
+                }
 
                 if (existingProject != null)
                 {
                     // Update fields from GIS data (matching legacy behavior)
                     existingProject.ProjectName = projectName.Length > 140 ? projectName[..140] : projectName;
-                    existingProject.ProjectStageID = sourceOrg.ProjectStageDefaultID;
+                    existingProject.ProjectStageID = projectStageID;
                     existingProject.LastUpdateGisUploadAttemptID = gisUploadAttemptID;
 
                     // Auto-approve if stage is not Planned and project is Draft/PendingApproval
-                    if (sourceOrg.ProjectStageDefaultID != (int)ProjectStageEnum.Planned
+                    if (projectStageID != (int)ProjectStageEnum.Planned
                         && (existingProject.ProjectApprovalStatusID == (int)ProjectApprovalStatusEnum.Draft
                             || existingProject.ProjectApprovalStatusID == (int)ProjectApprovalStatusEnum.PendingApproval))
                     {
                         existingProject.ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Approved;
                     }
 
-                    // Update dates if configured
-                    if (sourceOrg.ApplyStartDateToProject && request.StartDateMetadataAttributeID.HasValue &&
-                        firstMetadata.TryGetValue(request.StartDateMetadataAttributeID.Value, out var existingStartDateStr) &&
-                        DateTime.TryParse(existingStartDateStr, out var existingStartDate))
+                    // Update dates if configured. Widened by any treatments this project carries for
+                    // *other* programs, so a shared project keeps a span covering all of them - legacy
+                    // did this in CalculateStartDate / CalculateCompletionDate.
+                    var (updateStartDate, updateCompletionDate) = await WidenDatesFromOtherProgramTreatmentsAsync(
+                        dbContext, sourceOrg, existingProject.ProjectID, featureStartDate, featureCompletionDate);
+
+                    if (sourceOrg.ApplyStartDateToProject && updateStartDate.HasValue)
                     {
-                        existingProject.PlannedDate = DateOnly.FromDateTime(existingStartDate);
+                        existingProject.PlannedDate = DateOnly.FromDateTime(updateStartDate.Value);
                     }
 
-                    if (sourceOrg.ApplyCompletedDateToProject && request.CompletionDateMetadataAttributeID.HasValue &&
-                        firstMetadata.TryGetValue(request.CompletionDateMetadataAttributeID.Value, out var existingCompletionDateStr) &&
-                        DateTime.TryParse(existingCompletionDateStr, out var existingCompletionDate))
+                    if (sourceOrg.ApplyCompletedDateToProject && updateCompletionDate.HasValue)
                     {
-                        existingProject.CompletionDate = DateOnly.FromDateTime(existingCompletionDate);
+                        existingProject.CompletionDate = DateOnly.FromDateTime(updateCompletionDate.Value);
                     }
 
                     // Set description only if empty
@@ -540,42 +669,29 @@ public static class GisBulkImports
                 }
                 else
                 {
-                    // Look up ProjectTypeID from the source org's default name
-                    var projectTypeID = await dbContext.ProjectTypes
-                        .Where(pt => pt.ProjectTypeName == (sourceOrg.ProjectTypeDefaultName ?? ""))
-                        .Select(pt => pt.ProjectTypeID)
-                        .FirstOrDefaultAsync();
-                    if (projectTypeID == 0)
-                    {
-                        projectTypeID = await dbContext.ProjectTypes.Select(pt => pt.ProjectTypeID).FirstAsync();
-                    }
-
                     var newProject = new Project
                     {
                         ProjectName = projectName.Length > 140 ? projectName[..140] : projectName,
                         FhtProjectNumber = await Projects.GenerateFhtProjectNumberAsync(dbContext),
                         ProjectGisIdentifier = originalIdentifier.Length > 140 ? originalIdentifier[..140] : originalIdentifier,
-                        ProjectTypeID = projectTypeID,
-                        ProjectStageID = sourceOrg.ProjectStageDefaultID,
+                        ProjectTypeID = defaultProjectTypeID,
+                        ProjectStageID = projectStageID,
                         ProjectApprovalStatusID = (int)ProjectApprovalStatusEnum.Approved,
                         ProjectLocationSimpleTypeID = (int)ProjectLocationSimpleTypeEnum.None,
                         CreateGisUploadAttemptID = gisUploadAttemptID,
                         LastUpdateGisUploadAttemptID = gisUploadAttemptID
                     };
 
-                    // Set dates if configured
-                    if (sourceOrg.ApplyStartDateToProject && request.StartDateMetadataAttributeID.HasValue &&
-                        firstMetadata.TryGetValue(request.StartDateMetadataAttributeID.Value, out var startDateStr) &&
-                        DateTime.TryParse(startDateStr, out var startDate))
+                    // Set dates if configured. A brand-new project has no treatments yet, so there is
+                    // nothing to widen against.
+                    if (sourceOrg.ApplyStartDateToProject && featureStartDate.HasValue)
                     {
-                        newProject.PlannedDate = DateOnly.FromDateTime(startDate);
+                        newProject.PlannedDate = DateOnly.FromDateTime(featureStartDate.Value);
                     }
 
-                    if (sourceOrg.ApplyCompletedDateToProject && request.CompletionDateMetadataAttributeID.HasValue &&
-                        firstMetadata.TryGetValue(request.CompletionDateMetadataAttributeID.Value, out var completionDateStr) &&
-                        DateTime.TryParse(completionDateStr, out var completionDate))
+                    if (sourceOrg.ApplyCompletedDateToProject && featureCompletionDate.HasValue)
                     {
-                        newProject.CompletionDate = DateOnly.FromDateTime(completionDate);
+                        newProject.CompletionDate = DateOnly.FromDateTime(featureCompletionDate.Value);
                     }
 
                     // Set project description
@@ -594,11 +710,12 @@ public static class GisBulkImports
                         ProgramID = sourceOrg.ProgramID
                     });
 
-                    // Create default organization relationship
+                    // Create the lead implementer relationship — the crosswalked organization when
+                    // the GIS data maps to one, otherwise the source org's configured default.
                     dbContext.ProjectOrganizations.Add(new ProjectOrganization
                     {
                         ProjectID = newProject.ProjectID,
-                        OrganizationID = sourceOrg.DefaultLeadImplementerOrganizationID,
+                        OrganizationID = leadImplementerOrganizationID,
                         RelationshipTypeID = sourceOrg.RelationshipTypeForDefaultOrganizationID
                     });
 
@@ -686,6 +803,15 @@ public static class GisBulkImports
 
                 await dbContext.SaveChangesWithNoAuditingAsync();
 
+                // Private landowners and primary contact from the GIS metadata. Ports legacy's
+                // MakeProjectPeopleAndSave, which the rewrite dropped entirely even though the
+                // Landowner column mapping is still configured (and still posted by the UI).
+                if (importsPeople)
+                {
+                    await ApplyProjectLandownersAsync(
+                        dbContext, personLookup, existingProject.ProjectID, landownerValues, peopleCreatedThisIteration);
+                }
+
                 // Populate County / DNR Upland Region / Priority Landscape from the just-saved
                 // location geometries, mirroring the interactive project workflow. Runs inside the
                 // same transaction (atomic with the locations) and saves without auditing, matching
@@ -697,6 +823,15 @@ public static class GisBulkImports
             });
 
             // Apply outcomes after the transaction commits (retries won't double-count)
+            personLookup?.Merge(peopleCreatedThisIteration);
+
+            if (wasBlockedByProjectID)
+            {
+                result.ProjectsBlocked++;
+                result.BlockedProjects.Add(resultEntry);
+                continue;
+            }
+
             result.LocationsCreated += locationsCreatedThisIteration;
             if (wasCreated)
             {
@@ -710,66 +845,966 @@ public static class GisBulkImports
             }
         }
 
-        // Call stored proc for treatment imports
-        try
+        if (projectsSkippedForMissingCompletionDate > 0)
         {
-            // Resolve default TreatmentTypeID from source org name (fallback to Other)
-            var treatmentTypeID = TreatmentType.Other.TreatmentTypeID;
-            if (!string.IsNullOrEmpty(sourceOrg.TreatmentTypeDefaultName))
-            {
-                var treatmentType = TreatmentType.All.SingleOrDefault(x =>
-                    x.TreatmentTypeDisplayName.Equals(sourceOrg.TreatmentTypeDefaultName, StringComparison.InvariantCultureIgnoreCase));
-                if (treatmentType != null)
-                {
-                    treatmentTypeID = treatmentType.TreatmentTypeID;
-                }
-            }
-
-            var treatmentDetailedActivityTypeID = TreatmentDetailedActivityType.Other.TreatmentDetailedActivityTypeID;
-            var isFlattened = sourceOrg.ImportIsFlattened == true ? 1 : 0;
-
-            // Null metadata attribute IDs use -1 sentinel for the proc
-            int ToSqlID(int? id) => id ?? -1;
-
-            await ExecuteTreatmentImportProcAsync(dbContext, new Dictionary<string, int>
-            {
-                ["@piGisUploadAttemptID"] = gisUploadAttemptID,
-                ["@projectIdentifierGisMetadataAttributeID"] = request.ProjectIdentifierMetadataAttributeID,
-                ["@footprintAcresMetadataAttributeID"] = ToSqlID(request.FootprintAcresMetadataAttributeID),
-                ["@treatedAcresMetadataAttributeID"] = ToSqlID(request.TreatedAcresMetadataAttributeID),
-                ["@treatmentTypeMetadataAttributeID"] = ToSqlID(request.TreatmentTypeMetadataAttributeID),
-                ["@treatmentDetailedActivityTypeMetadataAttributeID"] = ToSqlID(request.TreatmentDetailedActivityTypeMetadataAttributeID),
-                ["@treatmentTypeID"] = treatmentTypeID,
-                ["@treatmentDetailedActivityTypeID"] = treatmentDetailedActivityTypeID,
-                ["@isFlattened"] = isFlattened,
-                ["@pruningAcresMetadataAttributeID"] = ToSqlID(request.PruningAcresMetadataAttributeID),
-                ["@thinningAcresMetadataAttributeID"] = ToSqlID(request.ThinningAcresMetadataAttributeID),
-                ["@chippingAcresMetadataAttributeID"] = ToSqlID(request.ChippingAcresMetadataAttributeID),
-                ["@masticationAcresMetadataAttributeID"] = ToSqlID(request.MasticationAcresMetadataAttributeID),
-                ["@grazingAcresMetadataAttributeID"] = ToSqlID(request.GrazingAcresMetadataAttributeID),
-                ["@lopScatterAcresMetadataAttributeID"] = ToSqlID(request.LopScatAcresMetadataAttributeID),
-                ["@biomassRemovalAcresMetadataAttributeID"] = ToSqlID(request.BiomassRemovalAcresMetadataAttributeID),
-                ["@handPileAcresMetadataAttributeID"] = ToSqlID(request.HandPileAcresMetadataAttributeID),
-                ["@handPileBurnAcresMetadataAttributeID"] = ToSqlID(request.HandPileBurnAcresMetadataAttributeID),
-                ["@machineBurnAcresMetadataAttributeID"] = ToSqlID(request.MachinePileBurnAcresMetadataAttributeID),
-                ["@broadcastBurnAcresMetadataAttributeID"] = ToSqlID(request.BroadcastBurnAcresMetadataAttributeID),
-                ["@otherBurnAcresMetadataAttributeID"] = ToSqlID(request.OtherAcresMetadataAttributeID),
-                ["@startDateMetadataAttributeID"] = ToSqlID(request.StartDateMetadataAttributeID),
-                ["@endDateMetadataAttributeID"] = ToSqlID(request.CompletionDateMetadataAttributeID),
-            });
-        }
-        catch (Exception ex)
-        {
-            // Treatments failed but the projects/locations created above are already committed, so this
-            // stays a warning on an otherwise successful import rather than failing the whole request.
-            // GisBulkImportController logs the populated Warnings so the failure reaches Datadog with
-            // the attempt ID attached — the bare EF "Failed executing DbCommand" entry has no context.
             result.Warnings.Add(
-                $"Treatment import failed, so no treatments were created for this upload. " +
-                $"Projects and locations were still imported. Error: {ex.Message}");
+                $"Skipped {projectsSkippedForMissingCompletionDate} project(s) with no completion date, because " +
+                $"this program's default project stage is Completed and it does not derive the stage from the data.");
+        }
+
+        // Call the treatment import proc. Sources configured to import detailed locations *instead
+        // of* treatments (Forest Stewardship, ProgramID 5) skip it entirely, matching legacy.
+        var treatmentsImported = true;
+        if (!sourceOrg.ImportAsDetailedLocationInsteadOfTreatments)
+        {
+            try
+            {
+                await ImportTreatmentsAsync(dbContext, gisUploadAttemptID, request, sourceOrg);
+            }
+            catch (Exception ex)
+            {
+                // Treatments failed but the projects/locations created above are already committed, so this
+                // stays a warning on an otherwise successful import rather than failing the whole request.
+                // GisBulkImportController logs the populated Warnings so the failure reaches Datadog with
+                // the attempt ID attached — the bare EF "Failed executing DbCommand" entry has no context.
+                treatmentsImported = false;
+                result.Warnings.Add(
+                    $"Treatment import failed, so no treatments were created for this upload. " +
+                    $"Projects and locations were still imported. Error: {ex.Message}");
+            }
+        }
+
+        // Legacy re-derived each touched project's type from its treatments *after* the treatment
+        // import (UpdateProjectTypesIfNeeded). The rewrite dropped this, so the source org's
+        // AdjustProjectTypeBasedOnTreatmentTypes flag became inert while still being editable in the
+        // Program admin UI — WADNR-2287. Skipped when the treatment import failed, so we never derive
+        // a type from a partially imported treatment set.
+        if (treatmentsImported)
+        {
+            await ApplyProjectTypeFromTreatmentTypesAsync(dbContext, sourceOrg, gisUploadAttemptID);
+        }
+
+        if (sourceOrg.ImportAsDetailedLocationInsteadOfTreatments)
+        {
+            // The proc is what normally sets Project.ProjectLocationPoint / ProjectLocationSimpleTypeID
+            // (its final UPDATE, joining Project -> Treatment -> ProjectLocation). Gating the proc off
+            // above would otherwise leave these sources with no simple location at all, so derive the
+            // centroid here the way legacy's MakeProjectLocationsAndSave did for exactly this flag.
+            await ApplySimpleLocationFromProjectAreasAsync(dbContext, gisUploadAttemptID);
+        }
+
+        // Assign the DNR Service Forestry Regional Coordinator to newly-created Landowner Assistance
+        // projects, from the DNR Upland Region they landed in. Ports legacy's AddProjectCoordinators,
+        // which ran right after the regions were calculated. Runs last because it depends on the
+        // regions AutoAssignGeographicRegionsAsync assigned inside the loop.
+        await ApplyRegionalCoordinatorsAsync(dbContext, gisUploadAttemptID);
+
+        // Clear this attempt's staged GIS features once everything above succeeded, so the staging
+        // tables don't grow without bound. Legacy called dbo.pClearGisImportTables, which does an
+        // unfiltered DELETE across every attempt's features plus an index rebuild and a full-scan
+        // statistics update — unsafe here, because it would destroy a concurrently running AGOL
+        // import's staged features and block the request while it ran. Scoped to this attempt, and
+        // skipped whenever anything went wrong so the staged data is still there to diagnose.
+        // Gated on an actual failure, NOT on Warnings being empty: Warnings also carries purely
+        // informational outcomes (features excluded by configuration, projects skipped for a missing
+        // completion date), and treating those as failures would permanently suppress the cleanup
+        // this block exists to perform.
+        if (treatmentsImported)
+        {
+            await ClearStagedFeaturesAsync(dbContext, gisUploadAttemptID);
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Builds the parameter set for dbo.procImportTreatmentsFromGisUploadAttempt and runs it.
+    /// </summary>
+    private static async Task ImportTreatmentsAsync(
+        WADNRDbContext dbContext,
+        int gisUploadAttemptID,
+        GisBulkImportRequest request,
+        GisUploadSourceOrganization sourceOrg)
+    {
+        // Resolve default TreatmentTypeID from source org name (fallback to Other)
+        var treatmentTypeID = TreatmentType.Other.TreatmentTypeID;
+        if (!string.IsNullOrEmpty(sourceOrg.TreatmentTypeDefaultName))
+        {
+            var treatmentType = TreatmentType.All.SingleOrDefault(x =>
+                x.TreatmentTypeDisplayName.Equals(sourceOrg.TreatmentTypeDefaultName, StringComparison.InvariantCultureIgnoreCase));
+            if (treatmentType != null)
+            {
+                treatmentTypeID = treatmentType.TreatmentTypeID;
+            }
+        }
+
+        var treatmentDetailedActivityTypeID = TreatmentDetailedActivityType.Other.TreatmentDetailedActivityTypeID;
+        var isFlattened = sourceOrg.ImportIsFlattened == true ? 1 : 0;
+
+        // Null metadata attribute IDs use -1 sentinel for the proc
+        int ToSqlID(int? id) => id ?? -1;
+
+        await ExecuteTreatmentImportProcAsync(dbContext, new Dictionary<string, int>
+        {
+            ["@piGisUploadAttemptID"] = gisUploadAttemptID,
+            ["@projectIdentifierGisMetadataAttributeID"] = request.ProjectIdentifierMetadataAttributeID,
+            ["@footprintAcresMetadataAttributeID"] = ToSqlID(request.FootprintAcresMetadataAttributeID),
+            ["@treatedAcresMetadataAttributeID"] = ToSqlID(request.TreatedAcresMetadataAttributeID),
+            ["@treatmentTypeMetadataAttributeID"] = ToSqlID(request.TreatmentTypeMetadataAttributeID),
+            ["@treatmentDetailedActivityTypeMetadataAttributeID"] = ToSqlID(request.TreatmentDetailedActivityTypeMetadataAttributeID),
+            ["@treatmentTypeID"] = treatmentTypeID,
+            ["@treatmentDetailedActivityTypeID"] = treatmentDetailedActivityTypeID,
+            ["@isFlattened"] = isFlattened,
+            ["@pruningAcresMetadataAttributeID"] = ToSqlID(request.PruningAcresMetadataAttributeID),
+            ["@thinningAcresMetadataAttributeID"] = ToSqlID(request.ThinningAcresMetadataAttributeID),
+            ["@chippingAcresMetadataAttributeID"] = ToSqlID(request.ChippingAcresMetadataAttributeID),
+            ["@masticationAcresMetadataAttributeID"] = ToSqlID(request.MasticationAcresMetadataAttributeID),
+            ["@grazingAcresMetadataAttributeID"] = ToSqlID(request.GrazingAcresMetadataAttributeID),
+            ["@lopScatterAcresMetadataAttributeID"] = ToSqlID(request.LopScatAcresMetadataAttributeID),
+            ["@biomassRemovalAcresMetadataAttributeID"] = ToSqlID(request.BiomassRemovalAcresMetadataAttributeID),
+            ["@handPileAcresMetadataAttributeID"] = ToSqlID(request.HandPileAcresMetadataAttributeID),
+            ["@handPileBurnAcresMetadataAttributeID"] = ToSqlID(request.HandPileBurnAcresMetadataAttributeID),
+            ["@machineBurnAcresMetadataAttributeID"] = ToSqlID(request.MachinePileBurnAcresMetadataAttributeID),
+            ["@broadcastBurnAcresMetadataAttributeID"] = ToSqlID(request.BroadcastBurnAcresMetadataAttributeID),
+            ["@otherBurnAcresMetadataAttributeID"] = ToSqlID(request.OtherAcresMetadataAttributeID),
+            ["@startDateMetadataAttributeID"] = ToSqlID(request.StartDateMetadataAttributeID),
+            ["@endDateMetadataAttributeID"] = ToSqlID(request.CompletionDateMetadataAttributeID),
+        });
+    }
+
+    /// <summary>
+    /// Whether a staged GeoJSON feature's geometry is usable as a project area. Ports legacy's
+    /// IsUsableFeatureGeoJson / ListOfValidGeoJsonTypes, which accepted Polygon and MultiPolygon only.
+    /// </summary>
+    private static bool IsUsableGeometry(NetTopologySuite.Geometries.Geometry geometry) =>
+        geometry is NetTopologySuite.Geometries.Polygon or NetTopologySuite.Geometries.MultiPolygon;
+
+    /// <summary>
+    /// Applies the source organization's include/exclude column configuration to the feature set.
+    /// Ports legacy's FilterListBasedOnIncludeExcludeCriteria: each configured column either
+    /// whitelists (keep only features whose value matches) or blacklists (drop those features).
+    /// Columns compose — each one narrows the set produced by the previous.
+    ///
+    /// Matching is case-insensitive and trimmed on both the column name and the values. Legacy used
+    /// ordinal comparisons, but the modern upload path lowercases every metadata attribute name
+    /// (UploadAndProcessFileAsync), so an ordinal match on the configured column name would silently
+    /// never fire for any mixed-case configuration.
+    /// </summary>
+    private static List<GisFeature> ApplyExcludeIncludeFilters(
+        List<GisFeature> features,
+        GisUploadSourceOrganization sourceOrg,
+        Dictionary<string, int> metadataAttributeIDByName,
+        Dictionary<int, Dictionary<int, string>> featureMetadata)
+    {
+        var excludeIncludeColumns = sourceOrg.GisExcludeIncludeColumns.ToList();
+        if (excludeIncludeColumns.Count == 0)
+        {
+            return features;
+        }
+
+        var filtered = features;
+        foreach (var column in excludeIncludeColumns)
+        {
+            var columnName = column.GisDefaultMappingColumnName?.Trim().ToLowerInvariant();
+            if (string.IsNullOrEmpty(columnName)
+                || !metadataAttributeIDByName.TryGetValue(columnName, out var metadataAttributeID))
+            {
+                // Configured against a column this upload doesn't carry — nothing to filter on.
+                continue;
+            }
+
+            var filterValues = column.GisExcludeIncludeColumnValues
+                .Select(x => x.GisExcludeIncludeColumnValueForFiltering?.Trim())
+                .Where(x => !string.IsNullOrEmpty(x))
+                .ToHashSet(StringComparer.InvariantCultureIgnoreCase);
+
+            if (filterValues.Count == 0)
+            {
+                continue;
+            }
+
+            bool MatchesFilterValue(GisFeature feature) =>
+                featureMetadata.TryGetValue(feature.GisFeatureID, out var metadata)
+                && metadata.TryGetValue(metadataAttributeID, out var value)
+                && value != null
+                && filterValues.Contains(value.Trim());
+
+            filtered = column.IsWhitelist
+                ? filtered.Where(MatchesFilterValue).ToList()
+                : filtered.Where(x => !MatchesFilterValue(x)).ToList();
+        }
+
+        return filtered;
+    }
+
+    /// <summary>
+    /// Distinct non-empty values of a metadata attribute across a project's features, in feature
+    /// order — the shape legacy's landowner / primary-contact dictionaries produced.
+    /// </summary>
+    private static List<string> DistinctMetadataValues(
+        IEnumerable<GisFeature> projectFeatures,
+        Dictionary<int, Dictionary<int, string>> featureMetadata,
+        int? metadataAttributeID)
+    {
+        if (!metadataAttributeID.HasValue)
+        {
+            return new List<string>();
+        }
+
+        var values = new List<string>();
+        var seen = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+        foreach (var feature in projectFeatures)
+        {
+            if (featureMetadata.TryGetValue(feature.GisFeatureID, out var metadata)
+                && metadata.TryGetValue(metadataAttributeID.Value, out var value)
+                && !string.IsNullOrWhiteSpace(value)
+                && seen.Add(value.Trim()))
+            {
+                values.Add(value.Trim());
+            }
+        }
+
+        return values;
+    }
+
+    /// <summary>
+    /// Minimal in-memory Person index used to match GIS landowner names and contact emails against
+    /// existing people, mirroring legacy's "load all People once" approach without dragging the
+    /// whole entity graph in.
+    /// </summary>
+    private sealed class PersonLookup
+    {
+        public List<(int PersonID, string FirstName, string LastName, DateTime CreateDate)> People { get; init; } = new();
+
+        public int? FindByName(string firstName, string lastName) => People
+            .Where(x => string.Equals(x.FirstName, firstName, StringComparison.InvariantCultureIgnoreCase)
+                && (string.Equals(x.LastName, lastName, StringComparison.InvariantCultureIgnoreCase)
+                    || (string.IsNullOrEmpty(x.LastName) && string.IsNullOrEmpty(lastName))))
+            .OrderBy(x => x.CreateDate)
+            .Select(x => (int?)x.PersonID)
+            .FirstOrDefault();
+
+        public void Add(int personID, string firstName, string lastName, DateTime createDate) =>
+            People.Add((personID, firstName, lastName, createDate));
+
+        /// <summary>Merges people created by a transaction that has now committed.</summary>
+        public void Merge(IEnumerable<(int PersonID, string FirstName, string LastName, DateTime CreateDate)> created)
+        {
+            foreach (var person in created)
+            {
+                People.Add(person);
+            }
+        }
+    }
+
+    private static string Truncate(string value, int maxLength) =>
+        value != null && value.Length > maxLength ? value[..maxLength] : value;
+
+    private static async Task<PersonLookup> LoadPersonLookupAsync(WADNRDbContext dbContext)
+    {
+        var people = await dbContext.People
+            .AsNoTracking()
+            .Select(x => new { x.PersonID, x.FirstName, x.LastName, x.CreateDate })
+            .ToListAsync();
+
+        return new PersonLookup
+        {
+            People = people
+                .Select(x => (x.PersonID, x.FirstName, x.LastName, x.CreateDate))
+                .ToList()
+        };
+    }
+
+    /// <summary>
+    /// Creates the ProjectPerson rows for a project's private landowners from the GIS metadata,
+    /// creating Person records for landowners we've never seen. Ports legacy's
+    /// GenerateProjectPersonListForPrivateLandowners, which the rewrite dropped entirely even though
+    /// the Landowner column mapping is still configured on DNR LOA NE and still posted by the UI.
+    ///
+    /// Matching legacy, existing landowner rows are replaced only when the import actually carries
+    /// landowner values — an upload with no landowner column never clears ones entered by hand.
+    /// </summary>
+    private static async Task ApplyProjectLandownersAsync(
+        WADNRDbContext dbContext,
+        PersonLookup personLookup,
+        int projectID,
+        List<string> landownerValues,
+        List<(int PersonID, string FirstName, string LastName, DateTime CreateDate)> createdPeople)
+    {
+        if (landownerValues.Count == 0)
+        {
+            return;
+        }
+
+        // Tracked removal rather than ExecuteDeleteAsync: this is at most a handful of rows per
+        // project, and it keeps the change inside the surrounding transaction's change tracker.
+        var existingLandownerRows = await dbContext.ProjectPeople
+            .Where(x => x.ProjectID == projectID
+                && x.ProjectPersonRelationshipTypeID == ProjectPersonRelationshipType.PrivateLandowner.ProjectPersonRelationshipTypeID)
+            .ToListAsync();
+        dbContext.ProjectPeople.RemoveRange(existingLandownerRows);
+
+        foreach (var landowner in landownerValues)
+        {
+            var (firstName, lastName) = SplitLandownerName(landowner);
+            if (string.IsNullOrWhiteSpace(firstName))
+            {
+                continue;
+            }
+
+            // Person.FirstName / LastName are varchar(100). GIS landowner values are unbounded text
+            // and routinely carry long trust names, so truncate the way every other string
+            // assignment in this pipeline does rather than letting a 2628 abort the whole import.
+            firstName = Truncate(firstName, PersonNameMaxLength);
+            lastName = Truncate(lastName, PersonNameMaxLength);
+
+            var personID = personLookup.FindByName(firstName, lastName);
+            if (personID == null)
+            {
+                var person = new Person
+                {
+                    FirstName = firstName,
+                    LastName = lastName,
+                    CreateDate = DateTime.UtcNow,
+                    IsActive = true,
+                    IsUser = false,
+                    ReceiveSupportEmails = false,
+                    CreatedAsPartOfBulkImport = true
+                };
+                dbContext.People.Add(person);
+                await dbContext.SaveChangesWithNoAuditingAsync();
+
+                dbContext.PersonRoles.Add(new PersonRole
+                {
+                    PersonID = person.PersonID,
+                    RoleID = Role.Unassigned.RoleID
+                });
+
+                // Buffered rather than written straight into personLookup: this runs inside the
+                // per-project transaction, and an execution-strategy retry rolls the Person insert
+                // back. Publishing the ID to the shared index before the commit would leave the
+                // retry resolving a PersonID that no longer exists and violating the ProjectPerson
+                // foreign key. The caller merges the buffer only after the transaction commits.
+                createdPeople.Add((person.PersonID, firstName, lastName, person.CreateDate));
+                personID = person.PersonID;
+            }
+
+            dbContext.ProjectPeople.Add(new ProjectPerson
+            {
+                ProjectID = projectID,
+                PersonID = personID.Value,
+                ProjectPersonRelationshipTypeID = ProjectPersonRelationshipType.PrivateLandowner.ProjectPersonRelationshipTypeID,
+                CreatedAsPartOfBulkImport = true
+            });
+        }
+
+        await dbContext.SaveChangesWithNoAuditingAsync();
+    }
+
+    /// <summary>
+    /// Splits a GIS landowner value into first/last name. Ports legacy's ExtractFirstName /
+    /// ExtractLastName: "Last, First" splits on the comma; anything else becomes the first name whole.
+    /// </summary>
+    private static (string FirstName, string LastName) SplitLandownerName(string landowner)
+    {
+        var parts = landowner.Split(',');
+        return parts.Length == 2
+            ? (parts[1].Trim(), parts[0].Trim())
+            : (landowner.Trim(), null);
+    }
+
+    /// <summary>
+    /// Assigns the DNR Service Forestry Regional Coordinator to projects this attempt created that
+    /// are in the Landowner Assistance program and landed in a DNR Upland Region that has one.
+    /// Ports legacy's AddProjectCoordinators.
+    /// </summary>
+    private static async Task ApplyRegionalCoordinatorsAsync(WADNRDbContext dbContext, int gisUploadAttemptID)
+    {
+        var coordinatorPairs = await dbContext.ProjectRegions
+            .AsNoTracking()
+            .Where(pr => pr.Project.CreateGisUploadAttemptID == gisUploadAttemptID
+                && pr.Project.ProjectPrograms.Any(pp => pp.ProgramID == Program.LandownerAssistanceProgramID)
+                && pr.DNRUplandRegion.DNRUplandRegionCoordinatorID != null)
+            .Select(pr => new { pr.ProjectID, PersonID = pr.DNRUplandRegion.DNRUplandRegionCoordinatorID!.Value })
+            .Distinct()
+            .ToListAsync();
+
+        if (coordinatorPairs.Count == 0)
+        {
+            return;
+        }
+
+        var relationshipTypeID = ProjectPersonRelationshipType.ServiceForestryRegionalCoordinator.ProjectPersonRelationshipTypeID;
+        var projectIDs = coordinatorPairs.Select(x => x.ProjectID).Distinct().ToList();
+
+        var existingPairs = (await dbContext.ProjectPeople
+                .AsNoTracking()
+                .Where(x => projectIDs.Contains(x.ProjectID) && x.ProjectPersonRelationshipTypeID == relationshipTypeID)
+                .Select(x => new { x.ProjectID, x.PersonID })
+                .ToListAsync())
+            .Select(x => (x.ProjectID, x.PersonID))
+            .ToHashSet();
+
+        var added = false;
+        foreach (var pair in coordinatorPairs)
+        {
+            if (!existingPairs.Add((pair.ProjectID, pair.PersonID)))
+            {
+                continue;
+            }
+
+            dbContext.ProjectPeople.Add(new ProjectPerson
+            {
+                ProjectID = pair.ProjectID,
+                PersonID = pair.PersonID,
+                ProjectPersonRelationshipTypeID = relationshipTypeID,
+                CreatedAsPartOfBulkImport = true
+            });
+            added = true;
+        }
+
+        if (added)
+        {
+            await dbContext.SaveChangesWithNoAuditingAsync();
+        }
+    }
+
+    /// <summary>
+    /// Sets Project.ProjectLocationPoint to the centroid of the project's imported project areas and
+    /// marks the simple location type as a point on the map.
+    ///
+    /// Only needed for sources that skip the treatment proc: the proc's final statement normally does
+    /// this, so gating it off would otherwise leave those projects with no simple location. Legacy
+    /// computed the same centroid inline for exactly these sources.
+    /// </summary>
+    private static async Task ApplySimpleLocationFromProjectAreasAsync(WADNRDbContext dbContext, int gisUploadAttemptID)
+    {
+        var projects = await dbContext.Projects
+            .Where(p => p.LastUpdateGisUploadAttemptID == gisUploadAttemptID)
+            .ToListAsync();
+
+        if (projects.Count == 0)
+        {
+            return;
+        }
+
+        var projectIDs = projects.Select(p => p.ProjectID).ToList();
+        var geometriesByProjectID = (await dbContext.ProjectLocations
+                .AsNoTracking()
+                .Where(pl => projectIDs.Contains(pl.ProjectID)
+                    && pl.ProjectLocationTypeID == (int)ProjectLocationTypeEnum.ProjectArea
+                    && pl.ProjectLocationGeometry != null)
+                .Select(pl => new { pl.ProjectID, pl.ProjectLocationGeometry })
+                .ToListAsync())
+            .GroupBy(x => x.ProjectID)
+            .ToDictionary(g => g.Key, g => g.Select(x => x.ProjectLocationGeometry!).ToList());
+
+        var anyChanged = false;
+        foreach (var project in projects)
+        {
+            if (!geometriesByProjectID.TryGetValue(project.ProjectID, out var geometries) || geometries.Count == 0)
+            {
+                continue;
+            }
+
+            // Union then centroid, matching the proc's geometry::UnionAggregate(...).STCentroid().
+            var combined = geometries[0];
+            for (var i = 1; i < geometries.Count; i++)
+            {
+                combined = combined.Union(geometries[i]);
+            }
+
+            var centroid = combined?.Centroid;
+            if (centroid == null || centroid.IsEmpty)
+            {
+                continue;
+            }
+
+            // Only fill an unset simple location. This runs for every project the attempt touched,
+            // not just newly-created ones, so overwriting unconditionally would replace a point a
+            // steward positioned by hand with the computed centroid on every nightly run.
+            if (project.ProjectLocationSimpleTypeID != (int)ProjectLocationSimpleTypeEnum.None
+                && project.ProjectLocationPoint != null)
+            {
+                continue;
+            }
+
+            project.ProjectLocationPoint = centroid;
+            project.ProjectLocationSimpleTypeID = (int)ProjectLocationSimpleTypeEnum.PointOnMap;
+            anyChanged = true;
+        }
+
+        if (anyChanged)
+        {
+            await dbContext.SaveChangesWithNoAuditingAsync();
+        }
+    }
+
+    /// <summary>
+    /// Deletes this attempt's staged GisFeature / GisFeatureMetadataAttribute rows once the import
+    /// has fully succeeded. See the call site for why this is scoped to one attempt rather than
+    /// calling legacy's dbo.pClearGisImportTables.
+    /// </summary>
+    private static async Task ClearStagedFeaturesAsync(WADNRDbContext dbContext, int gisUploadAttemptID)
+    {
+        var featureIDsQuery = dbContext.GisFeatures
+            .Where(f => f.GisUploadAttemptID == gisUploadAttemptID)
+            .Select(f => f.GisFeatureID);
+
+        // Bulk delete is the whole point here — an upload can stage hundreds of thousands of
+        // metadata rows — but ExecuteDelete is relational-only, so fall back to tracked removal on
+        // non-relational providers (the in-memory tests) to keep behaviour identical either way.
+        if (dbContext.Database.IsRelational())
+        {
+            await dbContext.GisFeatureMetadataAttributes
+                .Where(x => featureIDsQuery.Contains(x.GisFeatureID))
+                .ExecuteDeleteAsync();
+
+            await dbContext.GisFeatures
+                .Where(x => x.GisUploadAttemptID == gisUploadAttemptID)
+                .ExecuteDeleteAsync();
+            return;
+        }
+
+        var featureIDs = await featureIDsQuery.ToListAsync();
+        dbContext.GisFeatureMetadataAttributes.RemoveRange(
+            await dbContext.GisFeatureMetadataAttributes.Where(x => featureIDs.Contains(x.GisFeatureID)).ToListAsync());
+        dbContext.GisFeatures.RemoveRange(
+            await dbContext.GisFeatures.Where(x => x.GisUploadAttemptID == gisUploadAttemptID).ToListAsync());
+        await dbContext.SaveChangesWithNoAuditingAsync();
+    }
+
+    /// <summary>Person.FirstName / LastName are varchar(100); GIS landowner values are unbounded text.</summary>
+    private const int PersonNameMaxLength = 100;
+
+    /// <summary>1990-01-01 and 2100-01-01 as epoch milliseconds — the plausible range for a project date.</summary>
+    private const long EarliestPlausibleEpochMilliseconds = 631152000000L;
+    private const long LatestPlausibleEpochMilliseconds = 4102444800000L;
+
+    private const string CommercialProjectTypeName = "Commercial vegetation treatment";
+    private const string NonCommercialProjectTypeName = "Non-commercial vegetation treatment";
+    private const string PrescribedFireProjectTypeName = "Prescribed fire treatment";
+    private const string OtherProjectTypeName = "Other";
+
+    /// <summary>
+    /// Resolves the ProjectTypeID assigned to projects this import creates: the source
+    /// organization's configured ProjectTypeDefaultName, falling back to "Other".
+    ///
+    /// WADNR-2287: this previously fell back to <c>ProjectTypes.First()</c> — with no ORDER BY that
+    /// is whatever row SQL Server returns first, i.e. the lowest ProjectTypeID, which in production
+    /// is "Research and Monitoring". Every project created by a source org with no configured
+    /// default (DNR State Lands) landed on that arbitrary type. Legacy fell back to "Other".
+    ///
+    /// Throws rather than picking an arbitrary row if "Other" is missing — a wrong project type on
+    /// public-facing data is worse than a failed import.
+    /// </summary>
+    private static async Task<int> ResolveDefaultProjectTypeIDAsync(
+        WADNRDbContext dbContext, GisUploadSourceOrganization sourceOrg)
+    {
+        var projectTypes = await LoadProjectTypeIDsByNameAsync(dbContext);
+
+        var configuredName = sourceOrg.ProjectTypeDefaultName?.Trim();
+        if (!string.IsNullOrEmpty(configuredName) && projectTypes.TryGetValue(configuredName, out var configuredID))
+        {
+            return configuredID;
+        }
+
+        if (projectTypes.TryGetValue(OtherProjectTypeName, out var otherID))
+        {
+            return otherID;
+        }
+
+        throw new InvalidOperationException(
+            $"GIS bulk import cannot assign a project type: source organization " +
+            $"'{sourceOrg.GisUploadSourceOrganizationName}' has no usable ProjectTypeDefaultName " +
+            $"('{sourceOrg.ProjectTypeDefaultName}') and no ProjectType named '{OtherProjectTypeName}' exists to fall back to.");
+    }
+
+    /// <summary>
+    /// ProjectTypeID by trimmed name, case-insensitive. ProjectType is user-managed data (not a
+    /// seeded lookup), so IDs differ between environments — always resolve by name.
+    /// </summary>
+    private static async Task<Dictionary<string, int>> LoadProjectTypeIDsByNameAsync(WADNRDbContext dbContext)
+    {
+        var projectTypes = await dbContext.ProjectTypes
+            .AsNoTracking()
+            .Select(pt => new { pt.ProjectTypeID, pt.ProjectTypeName })
+            .ToListAsync();
+
+        return projectTypes
+            .Where(pt => !string.IsNullOrWhiteSpace(pt.ProjectTypeName))
+            .GroupBy(pt => pt.ProjectTypeName.Trim(), StringComparer.InvariantCultureIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First().ProjectTypeID, StringComparer.InvariantCultureIgnoreCase);
+    }
+
+    /// <summary>
+    /// OrganizationID by trimmed name, case-insensitive — used by the LeadImplementer crosswalk,
+    /// whose mapped values are organization names rather than IDs.
+    /// </summary>
+    private static async Task<Dictionary<string, int>> LoadOrganizationIDsByNameAsync(WADNRDbContext dbContext)
+    {
+        var organizations = await dbContext.Organizations
+            .AsNoTracking()
+            .Select(o => new { o.OrganizationID, o.OrganizationName })
+            .ToListAsync();
+
+        return organizations
+            .Where(o => !string.IsNullOrWhiteSpace(o.OrganizationName))
+            .GroupBy(o => o.OrganizationName.Trim(), StringComparer.InvariantCultureIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First().OrganizationID, StringComparer.InvariantCultureIgnoreCase);
+    }
+
+    /// <summary>
+    /// The programs whose projects an incoming GIS identifier may match. Normally just the source
+    /// organization's own program; when the org belongs to a GisUploadProgramMergeGrouping (the USFS
+    /// sources) every program in the grouping participates, so a project already created by a
+    /// sibling program is updated rather than duplicated.
+    /// </summary>
+    private static async Task<List<int>> ResolveMatchProgramIDsAsync(
+        WADNRDbContext dbContext, GisUploadSourceOrganization sourceOrg)
+    {
+        if (!sourceOrg.GisUploadProgramMergeGroupingID.HasValue)
+        {
+            return new List<int> { sourceOrg.ProgramID };
+        }
+
+        var programIDs = await dbContext.GisUploadSourceOrganizations
+            .AsNoTracking()
+            .Where(x => x.GisUploadProgramMergeGroupingID == sourceOrg.GisUploadProgramMergeGroupingID.Value)
+            .Select(x => x.ProgramID)
+            .Distinct()
+            .ToListAsync();
+
+        if (!programIDs.Contains(sourceOrg.ProgramID))
+        {
+            programIDs.Add(sourceOrg.ProgramID);
+        }
+
+        return programIDs;
+    }
+
+    /// <summary>
+    /// First non-empty value of the given metadata attribute across a project's features.
+    /// Returns null when the attribute isn't mapped or no feature carries a value.
+    /// </summary>
+    private static string FirstNonEmptyMetadataValue(
+        IEnumerable<GisFeature> projectFeatures,
+        Dictionary<int, Dictionary<int, string>> featureMetadata,
+        int? metadataAttributeID)
+    {
+        if (!metadataAttributeID.HasValue)
+        {
+            return null;
+        }
+
+        foreach (var feature in projectFeatures)
+        {
+            if (featureMetadata.TryGetValue(feature.GisFeatureID, out var metadata)
+                && metadata.TryGetValue(metadataAttributeID.Value, out var value)
+                && !string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves a date for a project from a metadata column across all of its features: the earliest
+    /// value for a start date, the latest for a completion date. Ports legacy CalculateStartDate /
+    /// CalculateCompletionDate.
+    ///
+    /// The epoch fallback is the important part. A GDB upload carries dates as text that
+    /// DateTime.TryParse understands, but the ArcGIS Online endpoints the nightly jobs read return
+    /// them as epoch milliseconds, which land here as bare digit strings. Legacy handled both; the
+    /// rewrite parsed only with DateTime.TryParse and only on the first feature, so the nightly LOA
+    /// and USFS imports resolved no dates at all.
+    /// </summary>
+    private static DateTime? ResolveDateFromFeatures(
+        IEnumerable<GisFeature> projectFeatures,
+        Dictionary<int, Dictionary<int, string>> featureMetadata,
+        int? metadataAttributeID,
+        bool useEarliest)
+    {
+        if (!metadataAttributeID.HasValue)
+        {
+            return null;
+        }
+
+        var rawValues = new List<string>();
+        foreach (var feature in projectFeatures)
+        {
+            if (featureMetadata.TryGetValue(feature.GisFeatureID, out var metadata)
+                && metadata.TryGetValue(metadataAttributeID.Value, out var value)
+                && !string.IsNullOrWhiteSpace(value))
+            {
+                rawValues.Add(value.Trim());
+            }
+        }
+
+        var distinctValues = rawValues.Distinct(StringComparer.InvariantCultureIgnoreCase).ToList();
+
+        var parsedDates = distinctValues
+            .Where(x => DateTime.TryParse(x, out _))
+            .Select(DateTime.Parse)
+            .ToList();
+
+        if (parsedDates.Count == 0)
+        {
+            // Bounded deliberately. long.TryParse accepts any digit string, so an unbounded epoch
+            // read would turn a yyyyMMdd value like "20240115" into 1970-01-01, and a numeric ID or
+            // tick count would make DateTimeOffset.FromUnixTimeMilliseconds throw and fail the whole
+            // import. Only values landing in a plausible project date range are accepted as epochs.
+            parsedDates = distinctValues
+                .Select(x => long.TryParse(x, out var ms) ? (long?)ms : null)
+                .Where(ms => ms.HasValue
+                    && ms.Value >= EarliestPlausibleEpochMilliseconds
+                    && ms.Value <= LatestPlausibleEpochMilliseconds)
+                .Select(ms => DateTimeOffset.FromUnixTimeMilliseconds(ms!.Value).UtcDateTime)
+                .ToList();
+        }
+
+        if (parsedDates.Count == 0)
+        {
+            return null;
+        }
+
+        return useEarliest ? parsedDates.Min() : parsedDates.Max();
+    }
+
+    /// <summary>
+    /// Widens a project start / completion date to cover treatments it carries for programs other
+    /// than the one being imported, so a project shared across programs keeps a span covering all of
+    /// them rather than being clipped to this import own features. Ports the second half of legacy
+    /// CalculateStartDate / CalculateCompletionDate.
+    /// </summary>
+    private static async Task<(DateTime? StartDate, DateTime? CompletionDate)> WidenDatesFromOtherProgramTreatmentsAsync(
+        WADNRDbContext dbContext,
+        GisUploadSourceOrganization sourceOrg,
+        int projectID,
+        DateTime? startDate,
+        DateTime? completionDate)
+    {
+        if (!sourceOrg.ApplyStartDateToProject && !sourceOrg.ApplyCompletedDateToProject)
+        {
+            return (startDate, completionDate);
+        }
+
+        var otherProgramDates = await dbContext.Treatments
+            .AsNoTracking()
+            .Where(t => t.ProjectID == projectID && t.ProgramID != null && t.ProgramID != sourceOrg.ProgramID)
+            .Select(t => new { t.TreatmentStartDate, t.TreatmentEndDate })
+            .ToListAsync();
+
+        if (otherProgramDates.Count == 0)
+        {
+            return (startDate, completionDate);
+        }
+
+        var otherStartDates = otherProgramDates
+            .Where(x => x.TreatmentStartDate != null)
+            .Select(x => x.TreatmentStartDate!.Value.ToDateTime(TimeOnly.MinValue))
+            .ToList();
+        if (otherStartDates.Count > 0)
+        {
+            var earliestOtherStart = otherStartDates.Min();
+            if (!startDate.HasValue || earliestOtherStart < startDate.Value)
+            {
+                startDate = earliestOtherStart;
+            }
+        }
+
+        var otherEndDates = otherProgramDates
+            .Where(x => x.TreatmentEndDate != null)
+            .Select(x => x.TreatmentEndDate!.Value.ToDateTime(TimeOnly.MinValue))
+            .ToList();
+        if (otherEndDates.Count > 0)
+        {
+            var latestOtherEnd = otherEndDates.Max();
+            if (!completionDate.HasValue || latestOtherEnd > completionDate.Value)
+            {
+                completionDate = latestOtherEnd;
+            }
+        }
+
+        return (startDate, completionDate);
+    }
+
+    /// <summary>
+    /// Project stage for a project in this import. Ports legacy's CalculateProjectStageIfNeeded:
+    /// the source org's configured default unless DataDeriveProjectStage is set, in which case the
+    /// raw GIS value is run through the ProjectStage crosswalk. WADNR-2287 — the rewrite dropped
+    /// this entirely and always used the configured default.
+    ///
+    /// Legacy used <c>Single(...)</c> on the crosswalk lookup, which threw and failed the whole
+    /// import when a source value had no crosswalk row. This falls back instead.
+    /// </summary>
+    private static int DeriveProjectStageID(
+        GisUploadSourceOrganization sourceOrg,
+        List<GisCrossWalkDefault> projectStageCrossWalks,
+        string projectStageSourceValue,
+        bool hasCompletionDate)
+    {
+        var projectStageID = sourceOrg.ProjectStageDefaultID;
+
+        if (!sourceOrg.DataDeriveProjectStage)
+        {
+            return projectStageID;
+        }
+
+        // Nothing has been completed without a completion date.
+        if (!hasCompletionDate)
+        {
+            projectStageID = ProjectStage.Planned.ProjectStageID;
+        }
+
+        if (string.IsNullOrWhiteSpace(projectStageSourceValue))
+        {
+            return projectStageID;
+        }
+
+        var mappedStageName = projectStageCrossWalks
+            .FirstOrDefault(x => string.Equals(
+                x.GisCrossWalkSourceValue?.Trim(), projectStageSourceValue.Trim(), StringComparison.InvariantCultureIgnoreCase))
+            ?.GisCrossWalkMappedValue;
+
+        if (string.IsNullOrWhiteSpace(mappedStageName))
+        {
+            // Unmapped source value — keep what we have rather than throwing (legacy bug).
+            return projectStageID;
+        }
+
+        var mappedStage = ProjectStage.All.SingleOrDefault(x => string.Equals(
+            x.ProjectStageName, mappedStageName.Trim(), StringComparison.InvariantCultureIgnoreCase));
+
+        // A mapped value that doesn't name a real stage means the source considered it done.
+        return mappedStage?.ProjectStageID ?? ProjectStage.Completed.ProjectStageID;
+    }
+
+    /// <summary>
+    /// Lead implementer organization for a newly-created project. Ports the mapping half of legacy's
+    /// UpdateProjectOrganizationRecords: crosswalk the raw GIS value onto an Organization name, then
+    /// onto an OrganizationID, falling back to the source org's configured default whenever the
+    /// value is absent, unmapped, or names an organization that doesn't exist.
+    ///
+    /// Legacy's bulk delete of existing ProjectOrganizations is deliberately not ported — this only
+    /// runs on the create path, matching the modern pipeline.
+    /// </summary>
+    private static int ResolveLeadImplementerOrganizationID(
+        GisUploadSourceOrganization sourceOrg,
+        List<GisCrossWalkDefault> leadImplementerCrossWalks,
+        Dictionary<string, int> organizationIDByName,
+        string leadImplementerSourceValue)
+    {
+        if (leadImplementerCrossWalks.Count == 0 || string.IsNullOrWhiteSpace(leadImplementerSourceValue))
+        {
+            return sourceOrg.DefaultLeadImplementerOrganizationID;
+        }
+
+        var mappedOrganizationName = leadImplementerCrossWalks
+            .FirstOrDefault(x => string.Equals(
+                x.GisCrossWalkSourceValue?.Trim(), leadImplementerSourceValue.Trim(), StringComparison.InvariantCultureIgnoreCase))
+            ?.GisCrossWalkMappedValue;
+
+        if (string.IsNullOrWhiteSpace(mappedOrganizationName))
+        {
+            return sourceOrg.DefaultLeadImplementerOrganizationID;
+        }
+
+        return organizationIDByName.TryGetValue(mappedOrganizationName.Trim(), out var organizationID)
+            ? organizationID
+            : sourceOrg.DefaultLeadImplementerOrganizationID;
+    }
+
+    /// <summary>
+    /// Re-derives each touched project's type from its treatments when the source organization has
+    /// AdjustProjectTypeBasedOnTreatmentTypes set. Ports legacy's UpdateProjectTypesIfNeeded, which
+    /// the rewrite dropped — WADNR-2287.
+    ///
+    /// A project is only reassigned when its treatments share exactly one distinct TreatmentTypeID;
+    /// a mixed or empty treatment set leaves the type alone. When the source is flattened, only
+    /// treatments with treated acres count, matching legacy.
+    ///
+    /// Scoped by LastUpdateGisUploadAttemptID, which the create path sets alongside
+    /// CreateGisUploadAttemptID, so this covers projects created *and* updated by this attempt.
+    /// </summary>
+    private static async Task ApplyProjectTypeFromTreatmentTypesAsync(
+        WADNRDbContext dbContext, GisUploadSourceOrganization sourceOrg, int gisUploadAttemptID)
+    {
+        if (!sourceOrg.AdjustProjectTypeBasedOnTreatmentTypes)
+        {
+            return;
+        }
+
+        var projectTypeIDsByName = await LoadProjectTypeIDsByNameAsync(dbContext);
+        var projectTypeIDByTreatmentTypeID = new Dictionary<int, int>();
+        void MapTreatmentType(TreatmentType treatmentType, string projectTypeName)
+        {
+            if (projectTypeIDsByName.TryGetValue(projectTypeName, out var projectTypeID))
+            {
+                projectTypeIDByTreatmentTypeID[treatmentType.TreatmentTypeID] = projectTypeID;
+            }
+        }
+
+        MapTreatmentType(TreatmentType.Commercial, CommercialProjectTypeName);
+        MapTreatmentType(TreatmentType.NonCommercial, NonCommercialProjectTypeName);
+        MapTreatmentType(TreatmentType.PrescribedFire, PrescribedFireProjectTypeName);
+
+        if (projectTypeIDByTreatmentTypeID.Count == 0)
+        {
+            return;
+        }
+
+        var projects = await dbContext.Projects
+            .Where(p => p.LastUpdateGisUploadAttemptID == gisUploadAttemptID)
+            .ToListAsync();
+
+        if (projects.Count == 0)
+        {
+            return;
+        }
+
+        var projectIDs = projects.Select(p => p.ProjectID).ToList();
+        var treatmentsQuery = dbContext.Treatments
+            .AsNoTracking()
+            .Where(t => projectIDs.Contains(t.ProjectID));
+
+        if (sourceOrg.ImportIsFlattened == true)
+        {
+            treatmentsQuery = treatmentsQuery.Where(t => t.TreatmentTreatedAcres > 0);
+        }
+
+        var treatmentTypeIDsByProjectID = (await treatmentsQuery
+                .Select(t => new { t.ProjectID, t.TreatmentTypeID })
+                .Distinct()
+                .ToListAsync())
+            .GroupBy(t => t.ProjectID)
+            .ToDictionary(g => g.Key, g => g.Select(t => t.TreatmentTypeID).ToList());
+
+        var anyChanged = false;
+        foreach (var project in projects)
+        {
+            if (!treatmentTypeIDsByProjectID.TryGetValue(project.ProjectID, out var treatmentTypeIDs)
+                || treatmentTypeIDs.Count != 1)
+            {
+                continue;
+            }
+
+            if (!projectTypeIDByTreatmentTypeID.TryGetValue(treatmentTypeIDs[0], out var derivedProjectTypeID)
+                || project.ProjectTypeID == derivedProjectTypeID)
+            {
+                continue;
+            }
+
+            project.ProjectTypeID = derivedProjectTypeID;
+            anyChanged = true;
+        }
+
+        if (anyChanged)
+        {
+            await dbContext.SaveChangesWithNoAuditingAsync();
+        }
     }
 
     /// <summary>

--- a/WADNR.EFModels/Entities/GisBulkImport.StaticHelpers.cs
+++ b/WADNR.EFModels/Entities/GisBulkImport.StaticHelpers.cs
@@ -414,6 +414,16 @@ public static class GisBulkImports
         // the features, matching legacy's FilterListBasedOnIncludeExcludeCriteria. The rewrite loaded
         // this configuration and then never read it, so every program's whitelist/blacklist was inert
         // — DNR State Lands has a blacklist on technique_cd that was being ignored entirely.
+        //
+        // Scope note: this filters the in-memory feature list only, so excluded features are left out
+        // of project and location creation but are still visible to
+        // dbo.procImportTreatmentsFromGisUploadAttempt, which reads dbo.GisFeature scoped solely by
+        // GisUploadAttemptID. An excluded feature can therefore still produce a Treatment. That is
+        // deliberate: legacy behaved exactly the same way, and this change is scoped to restoring
+        // legacy behaviour rather than extending it. Pushing the exclusion into the proc is a
+        // separate change, and one worth making together with correcting the column-name mismatch
+        // that currently stops this filter matching anything in production (the configuration names
+        // technique_cd; uploads stage the 10-character truncated technique_).
         var featureCountBeforeFiltering = features.Count;
         features = ApplyExcludeIncludeFilters(features, sourceOrg, metadataAttributeIDByName, featureMetadata);
         var featuresExcluded = featureCountBeforeFiltering - features.Count;

--- a/WADNR.EFModels/Entities/GisBulkImport.StaticHelpers.cs
+++ b/WADNR.EFModels/Entities/GisBulkImport.StaticHelpers.cs
@@ -871,16 +871,22 @@ public static class GisBulkImports
             {
                 await ImportTreatmentsAsync(dbContext, gisUploadAttemptID, request, sourceOrg);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 // Treatments failed but the projects/locations created above are already committed, so this
                 // stays a warning on an otherwise successful import rather than failing the whole request.
-                // GisBulkImportController logs the populated Warnings so the failure reaches Datadog with
-                // the attempt ID attached — the bare EF "Failed executing DbCommand" entry has no context.
+                //
+                // The exception message is deliberately NOT surfaced here. Warnings are returned to the
+                // caller by GisBulkImportController, and a raw SQL/proc error is not something to hand
+                // back over the API even on an admin-only endpoint. The detail is still recoverable:
+                // GisBulkImportController logs this warning with the attempt ID attached, and EF's own
+                // "Failed executing DbCommand" entry for the failing proc call sits in the same request
+                // trace, so the two correlate.
                 treatmentsImported = false;
                 result.Warnings.Add(
-                    $"Treatment import failed, so no treatments were created for this upload. " +
-                    $"Projects and locations were still imported. Error: {ex.Message}");
+                    "Treatment import failed, so no treatments were created for this upload. Projects and " +
+                    $"locations were still imported. Quote GIS upload attempt {gisUploadAttemptID} when " +
+                    "reporting this so the underlying error can be located in the server logs.");
             }
         }
 


### PR DESCRIPTION
## The bug

The GDB bulk upload assigned newly created projects a Project Type nothing in the program's configuration pointed at — DNR State Lands projects were landing on **"Research and Monitoring"**. Jen verified both her program mapping and her source data were correct, and they were.

Two compounding defects, both introduced when this pipeline was rewritten from `ProjectFirma.Web` onto the API:

1. With no matching `ProjectTypeDefaultName`, the fallback was `ProjectTypes.First()`. With no `ORDER BY` that is the lowest `ProjectTypeID` — "Research and Monitoring" in production. Legacy fell back to `"Other"`.
2. `AdjustProjectTypeBasedOnTreatmentTypes` was never honoured. Legacy re-derived each project's type from its treatments after the treatment import; the rewrite dropped that step while leaving the setting editable in the Program admin UI, so it read as working.

**442 production projects affected**, all created by the two uploads on 2026-07-02, all in DNR State Lands.

## What else the audit turned up

Auditing the legacy controller against this pipeline method-by-method found further behaviours silently dropped in the same rewrite. All were still configurable, so all appeared live:

- `GisExcludeIncludeColumns` whitelist/blacklist filtering
- `DataDeriveProjectStage` and the ProjectStage crosswalk
- the LeadImplementer organization crosswalk
- `ImportAsDetailedLocationInsteadOfTreatments` gating the treatment proc
- `GisUploadProgramMergeGrouping` cross-program project matching
- private landowner `ProjectPerson` creation
- DNR Service Forestry Regional Coordinator assignment
- the `RequiresCompletionDate` skip
- block-list entries referencing a `ProjectID`
- **epoch-millisecond date parsing** — the ArcGIS Online feeds encode dates this way, so the nightly LOA and USFS imports were resolving no dates at all
- Polygon/MultiPolygon geometry filtering at upload

Two legacy *bugs* were corrected rather than reproduced: an unmapped ProjectStage crosswalk value threw instead of falling back, and landowner names were written to `Person` without truncation.

One self-inflicted issue caught in review: gating the treatment proc would have left detailed-location sources with **no simple location at all**, since the proc is the only thing that populated `Project.ProjectLocationPoint`. Now set explicitly when the proc is skipped.

## Data fix

Release script `0009`:

- **442** mis-typed projects → 202 Non-commercial / 170 Prescribed fire / 70 Other
- **437** missing regional coordinator records backfilled

The code fix alone is not sufficient: it corrects 372 of the 442 on the next upload, but the other 70 are absent from the current State Lands extract, so no re-upload would ever reach them.

Coordinators are backfilled by script rather than by extending the code to the update path — doing it on update would silently re-add a coordinator a steward had removed, on every nightly run.

## Verification

Rehearsed against fresh production restores, three ways — script only, import only, and both:

- **Exactly 442 project types and 437 coordinator records change.** Nothing else moves across all 3,914 State Lands projects: no stage, approval, date, or attachment changes; no projects created or removed.
- The fixed importer and the release script **independently produce the identical 202/170/70 split**.
- A real `2026_06_SL_Non_Comm.gdb` import was run end to end through the actual proc.
- The script is idempotent and order-independent with respect to any import that lands first.

The LOA self-heal claim was exercised against the **live ArcGIS Online service**, across the 655 projects created since the migration:

| | before | after |
|---|---|---|
| landowner records | 21.7% | **99.7%** |
| completion dates | 0.8% | **30.5%** |
| treatments | 3 | **656** |

Pre-migration baselines are 99.9% and 34.8%, so both are back to legacy levels.

**752 tests pass, 2 skipped** (the opt-in AGOL tests).

## Behaviour changes reviewers should know about

- **Staged features are cleared after a successful import.** Legacy did this globally via `dbo.pClearGisImportTables`; ours is scoped to the attempt and skipped on failure. An attempt's feature grid will be empty afterwards.
- **`DataDeriveProjectStage` is now live** for programs 1, 3, 4, 6. Measured as a no-op for State Lands (every crosswalked value already matched), but it is a real change for the others.
- **Merge-grouping matching is now live** for the USFS programs — it stops *new* cross-program duplicates; it does not merge existing ones.

## Deliberately out of scope

- **Include/exclude filtering is in-memory only.** Excluded features remain visible to `procImportTreatmentsFromGisUploadAttempt`, which reads `dbo.GisFeature` scoped solely by attempt ID, so an excluded feature can still produce a Treatment. **Legacy behaved identically**, and this change set is scoped to restoring behaviour, not extending it. Documented at the call site. Worth doing alongside the config fix below.
- An unmapped stage crosswalk value defaulting to `Completed` — faithful legacy behaviour; changing it is a product decision.

## Configuration problems found along the way (not code — separate tickets)

- **DNR State Lands' mappings don't match its GDB.** The exclude/include filter names `technique_cd` and four of seven default mappings name `acres_treated` / `fma_status_cd`, but uploads stage 10-character truncated names (`technique_`, `acres_trea`, `fma_status`). The "exclude NATURAL / SEED_GRASS / APPLY_BARRIER" filter has therefore **never excluded anything**, and four mappings must be set by hand every upload.
- **Service Forestry** has `ApplyStartDateToProject` on but no start-date column mapped, so planned dates never populate.
- `GisBulkImportResult.TreatmentsCreated` is declared but never assigned, so the import summary always reports 0.

## Notes

- Does **not** include follow-up #1 from the Jira thread (surfacing GIS upload provenance in the Project Detail UI). This branch touches no frontend code.
- `LoaAgolSelfHealTests` is `[Ignore]`d and must stay that way — it authenticates to DNR's ArcGIS org and downloads the full LOA feature set. Service URLs come from the gitignored `environment.json`, not source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
