### PR TITLE
Pin the Helm version installed by the deploy pipeline

### DIFF
--- a/Build/azure-pipelines.yml
+++ b/Build/azure-pipelines.yml
@@ -496,6 +496,10 @@ stages:
             displayName: 'Install Helm 3.8.0'
             inputs:
               helmVersion: 3.8.0
+              # Must stay false. When true the task ignores helmVersion, resolves
+              # "latest" from the GitHub releases API, and on lookup failure falls
+              # back to its hardcoded v3.1.2 - which predates --create-namespace.
+              checkLatestHelmVersion: false
               installKubectl: true
 
           - task: Kubernetes@1


### PR DESCRIPTION
## Problem

The production Helm deploy failed with:

```
Error: unknown flag: --create-namespace
```

The log shows the upgrade running `/opt/hostedtoolcache/helm/3.1.2/x64/linux-amd64/helm`, even though the pipeline asks for Helm 3.8.0. `--create-namespace` was added in Helm 3.2, so 3.1.2 rejects it outright.

## Cause

`HelmInstaller@0` defaults `checkLatestHelmVersion` to `true`. When that is on, the task ignores the pinned `helmVersion`, resolves "latest" from the GitHub releases API, and — when that lookup fails — silently falls back to the version hardcoded in the task, `v3.1.2`. That fallback is what this run got.

Nothing in the repo caused the failure; prior prod deploys succeeded because the GitHub lookup returned a real "latest".

## Fix

Set `checkLatestHelmVersion: false` so the existing `3.8.0` pin is authoritative and the GitHub API call is off the deploy path entirely.

## Notes

- Re-running the failed stage replays the original run's YAML, so it will not pick this up — it needs a fresh run off `develop`.
- Consider bumping the pin past 3.8.0 in a follow-up; this change deliberately keeps the version the pipeline already declared so the only behavior change is determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
